### PR TITLE
Add a tao global parameter opti_write_var_file to enable inhibiting writing var*.out files when optimizing

### DIFF
--- a/tao/code/tao_de_optimizer.f90
+++ b/tao/code/tao_de_optimizer.f90
@@ -69,7 +69,7 @@ print *, 'tao_de_optimizer merit for rank ', merit, s%mpi%rank
 
 call tao_set_opt_vars (var_vec, s%global%optimizer_var_limit_warn)
 merit_end = tao_merit ()
-if (s%opti_write_var_file) call tao_var_write (s%global%var_out_file)
+if (s%global%opti_write_var_file) call tao_var_write (s%global%var_out_file)
 
 write (line, '(a, es14.6)') 'Merit start:', merit_start
 call out_io (s_blank$, r_name, line)
@@ -151,7 +151,7 @@ endif
 
 if (this_merit <= 0.98*merit_min_type .or. t_delta > 10) then
   write (line, '(a, es14.6)') ' So far the minimum is ', merit_min
-  if (s%opti_write_var_file) call tao_var_write (s%global%var_out_file)
+  if (s%global%opti_write_var_file) call tao_var_write (s%global%var_out_file)
 
   if (calc_ok) then
     call out_io (s_blank$, r_name, stars, line, stars)

--- a/tao/code/tao_de_optimizer.f90
+++ b/tao/code/tao_de_optimizer.f90
@@ -69,7 +69,7 @@ print *, 'tao_de_optimizer merit for rank ', merit, s%mpi%rank
 
 call tao_set_opt_vars (var_vec, s%global%optimizer_var_limit_warn)
 merit_end = tao_merit ()
-call tao_var_write (s%global%var_out_file)
+if (s%opti_write_var_file) call tao_var_write (s%global%var_out_file)
 
 write (line, '(a, es14.6)') 'Merit start:', merit_start
 call out_io (s_blank$, r_name, line)
@@ -151,7 +151,7 @@ endif
 
 if (this_merit <= 0.98*merit_min_type .or. t_delta > 10) then
   write (line, '(a, es14.6)') ' So far the minimum is ', merit_min
-  call tao_var_write (s%global%var_out_file)
+  if (s%opti_write_var_file) call tao_var_write (s%global%var_out_file)
 
   if (calc_ok) then
     call out_io (s_blank$, r_name, stars, line, stars)

--- a/tao/code/tao_lm_optimizer_mod.f90
+++ b/tao/code/tao_lm_optimizer_mod.f90
@@ -112,7 +112,7 @@ do i = 1, s%global%n_opti_cycles+1
 
   if (finished .or. i == s%global%n_opti_cycles+1) then
     a_lambda = 0  ! tell mrqmin we are finished
-    if (s%opti_write_var_file) call tao_var_write (s%global%var_out_file)
+    if (s%global%opti_write_var_file) call tao_var_write (s%global%var_out_file)
   endif
 
   call super_mrqmin (y, weight, a, chi_sq, tao_mrq_func, storage, a_lambda, status)

--- a/tao/code/tao_lm_optimizer_mod.f90
+++ b/tao/code/tao_lm_optimizer_mod.f90
@@ -112,7 +112,7 @@ do i = 1, s%global%n_opti_cycles+1
 
   if (finished .or. i == s%global%n_opti_cycles+1) then
     a_lambda = 0  ! tell mrqmin we are finished
-    call tao_var_write (s%global%var_out_file)
+    if (s%opti_write_var_file) call tao_var_write (s%global%var_out_file)
   endif
 
   call super_mrqmin (y, weight, a, chi_sq, tao_mrq_func, storage, a_lambda, status)

--- a/tao/code/tao_lmdif_optimizer.f90
+++ b/tao/code/tao_lmdif_optimizer.f90
@@ -134,7 +134,7 @@ if (merit > merit_at_min) then
   call out_io (s_blank$, r_name, line)
 endif
 
-call tao_var_write (s%global%var_out_file)
+if (s%opti_write_var_file) call tao_var_write (s%global%var_out_file)
 deallocate (var_at_min)
 
 end subroutine

--- a/tao/code/tao_lmdif_optimizer.f90
+++ b/tao/code/tao_lmdif_optimizer.f90
@@ -134,7 +134,7 @@ if (merit > merit_at_min) then
   call out_io (s_blank$, r_name, line)
 endif
 
-if (s%opti_write_var_file) call tao_var_write (s%global%var_out_file)
+if (s%global%opti_write_var_file) call tao_var_write (s%global%var_out_file)
 deallocate (var_at_min)
 
 end subroutine

--- a/tao/code/tao_python_cmd.f90
+++ b/tao/code/tao_python_cmd.f90
@@ -4542,6 +4542,7 @@ case ('global')
   nl=incr(nl); write (li(nl), lmt) 'beam_timer_on;LOGIC;T;',                  s%global%beam_timer_on
   nl=incr(nl); write (li(nl), lmt) 'var_limits_on;LOGIC;T;',                  s%global%var_limits_on
   nl=incr(nl); write (li(nl), lmt) 'only_limit_opt_vars;LOGIC;T;',            s%global%only_limit_opt_vars
+  nl=incr(nl); write (li(nl), lmt) 'opti_write_var_file;LOGIC;T;',            s%global%opti_write_var_file
   nl=incr(nl); write (li(nl), lmt) 'optimizer_var_limit_warn;LOGIC;T;',       s%global%optimizer_var_limit_warn
   nl=incr(nl); write (li(nl), lmt) 'optimizer_allow_user_abort;LOGIC;T;',     s%global%optimizer_allow_user_abort
   nl=incr(nl); write (li(nl), lmt) 'rf_on;LOGIC;T;',                          s%global%rf_on
@@ -4593,6 +4594,7 @@ case ('global:optimization')
 
   nl=incr(nl); write (li(nl), amt) 'optimizer;ENUM;T;',                       trim(s%global%optimizer)
   nl=incr(nl); write (li(nl), amt) 'var_out_file;FILE;T;',                    trim(s%global%var_out_file)
+  nl=incr(nl); write (li(nl), lmt) 'opti_write_var_file;LOGIC;T;',            s%global%opti_write_var_file
 
   nl=incr(nl); write (li(nl), lmt) 'derivative_recalc;LOGIC;T;',              s%global%derivative_recalc
   nl=incr(nl); write (li(nl), lmt) 'derivative_uses_design;LOGIC;T;',         s%global%derivative_uses_design

--- a/tao/code/tao_show_this.f90
+++ b/tao/code/tao_show_this.f90
@@ -2105,6 +2105,7 @@ case ('global')
     nl=nl+1; write(lines(nl), lmt) '  %label_keys                    = ', s%global%label_keys
     nl=nl+1; write(lines(nl), lmt) '  %lattice_calc_on               = ', s%global%lattice_calc_on
     nl=nl+1; write(lines(nl), lmt) '  %only_limit_opt_vars           = ', s%global%only_limit_opt_vars
+    nl=nl+1; write(lines(nl), lmt) '  %opti_write_var_file           = ', s%global%opti_write_var_file
     nl=nl+1; write(lines(nl), lmt) '  %optimizer_var_limit_warn      = ', s%global%optimizer_var_limit_warn
     nl=nl+1; write(lines(nl), amt) '  %phase_units                   = ', angle_units_name(s%global%phase_units)
     nl=nl+1; write(lines(nl), lmt) '  %rad_int_calc_on               = ', s%global%rad_int_calc_on
@@ -6403,6 +6404,7 @@ nl=nl+1; write(lines(nl), imt) '  %n_opti_cycles                 = ', s%global%n
 
 nl=nl+1; write(lines(nl), amt) '  %optimizer                     = ', quote(s%global%optimizer)
 nl=nl+1; write(lines(nl), amt) '  %var_out_file                  = ', quote(s%global%var_out_file)
+nl=nl+1; write(lines(nl), lmt) '  %opti_write_var_file           = ', s%global%opti_write_var_file
 
 nl=nl+1; write(lines(nl), lmt) '  %derivative_recalc             = ', s%global%derivative_recalc
 nl=nl+1; write(lines(nl), lmt) '  %derivative_uses_design        = ', s%global%derivative_uses_design

--- a/tao/code/tao_struct.f90
+++ b/tao/code/tao_struct.f90
@@ -654,7 +654,6 @@ type tao_global_struct
   integer :: srdt_gen_n_slices = 10              ! Number times to slice elements for summation RDT calculation
   integer :: datum_err_messages_max = 10         ! Maximum number of error messages per cycle.
   integer :: srdt_sxt_n_slices = 20              ! Number times to slice sextupoles for summation RDT calculation
-  logical :: opti_write_var_file = .true.        ! "run" command writes var_out_file
   logical :: srdt_use_cache = .true.             ! Create cache for SRDT calculations.  Can use lots of memory if srdt_*_n_slices large.
   character(12) :: quiet = 'off'                 ! "all", or "output". Print I/O when running a command file?
   character(16) :: random_engine = ''            ! Non-beam random number engine
@@ -683,6 +682,7 @@ type tao_global_struct
   logical :: only_limit_opt_vars = .false.            ! Only apply limits to variables used in optimization.
   logical :: opt_with_ref = .false.                   ! Use reference data in optimization?
   logical :: opt_with_base = .false.                  ! Use base data in optimization?
+  logical :: opti_write_var_file = .true.             ! "run" command writes var_out_file
   logical :: optimizer_allow_user_abort = .true.      ! See Tao manual for more details.
   logical :: optimizer_var_limit_warn = .true.        ! Warn when vars reach a limit with optimization.
   logical :: plot_on = .true.                         ! Do plotting?

--- a/tao/code/tao_struct.f90
+++ b/tao/code/tao_struct.f90
@@ -654,6 +654,7 @@ type tao_global_struct
   integer :: srdt_gen_n_slices = 10              ! Number times to slice elements for summation RDT calculation
   integer :: datum_err_messages_max = 10         ! Maximum number of error messages per cycle.
   integer :: srdt_sxt_n_slices = 20              ! Number times to slice sextupoles for summation RDT calculation
+  integer :: opti_write_var_file = .true.        ! "run" command writes var_out_file
   logical :: srdt_use_cache = .true.             ! Create cache for SRDT calculations.  Can use lots of memory if srdt_*_n_slices large.
   character(12) :: quiet = 'off'                 ! "all", or "output". Print I/O when running a command file?
   character(16) :: random_engine = ''            ! Non-beam random number engine

--- a/tao/code/tao_struct.f90
+++ b/tao/code/tao_struct.f90
@@ -654,7 +654,7 @@ type tao_global_struct
   integer :: srdt_gen_n_slices = 10              ! Number times to slice elements for summation RDT calculation
   integer :: datum_err_messages_max = 10         ! Maximum number of error messages per cycle.
   integer :: srdt_sxt_n_slices = 20              ! Number times to slice sextupoles for summation RDT calculation
-  integer :: opti_write_var_file = .true.        ! "run" command writes var_out_file
+  logical :: opti_write_var_file = .true.        ! "run" command writes var_out_file
   logical :: srdt_use_cache = .true.             ! Create cache for SRDT calculations.  Can use lots of memory if srdt_*_n_slices large.
   character(12) :: quiet = 'off'                 ! "all", or "output". Print I/O when running a command file?
   character(16) :: random_engine = ''            ! Non-beam random number engine

--- a/tao/doc/initialization.tex
+++ b/tao/doc/initialization.tex
@@ -583,7 +583,7 @@ supersede everything else.
 \index{single_mode}\index{lm_opt_deriv_reinit}
 \index{label_lattice_elements}\index{label_keys}\index{derivative_recalc}
 \index{lattice_calc_on}\index{print_command}\index{default_init_file}\index{derivative_uses_design}
-\index{current_init_file}\index{var_out_file}\index{draw_curve_off_scale_warn}
+\index{current_init_file}\index{var_out_file}\index{draw_curve_off_scale_warn}\index{opti_write_var_file}
 The \vn{tao_global_struct} structure contains \tao global parameters. The components of this structure are:
 \begin{example}
 type tao_global_struct:
@@ -629,6 +629,7 @@ type tao_global_struct:
   only_limit_opt_vars = F          ! Apply limits only if variable is used in optimization?
   opt_with_ref = F                 ! use reference data in optimization?
   opt_with_base = F                ! use base data in optimization?
+  opti_var_write_file = T          ! ``run'' command writes var_out_file
   optimizer_allow_user_abort = T   ! See below.
   optimizer_var_limit_warn = T     ! Warn when vars reach a limit when optimizing?
   plot_on = T                      ! Do plotting?
@@ -827,6 +828,10 @@ The default file name is ``\vn{var\#.out}''. If the file contains a hash (``\#''
 file will be generated for each universe with the universe index substituted for the hash symbol.
 For example, with the default file name, the name of the file for universe 1 will be ``\vn{var1.out}''.
 If the file name is blank, the results will be printed on the screen and no file will be generated.
+%
+  \item{\vn{global%opti_write_var_file}} \Newline
+Normally the optimizer writes to \vn{global%var_out_file}. Setting \vn{global%opti_write_var_file}
+to \texttt{F} prevents this.
 \end{description}
 
 Random number generation in \tao is divided into two categories: Random numbers used for


### PR DESCRIPTION
Maintain current behavior as the default (`opti_write_var_file=t`). Added documentation, set/show/python.