### PR TITLE
Add `${CMAKE_ARGS}` for conda-forge recipe

### DIFF
--- a/util/mk-mkd
+++ b/util/mk-mkd
@@ -166,7 +166,7 @@ case ${@} in
 	        ACC_CMAKE_ARGS=()
 	    fi
 
-	    cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} "${ACC_CMAKE_ARGS[@]}" .. || exit 1
+	    cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${CMAKE_ARGS} "${ACC_CMAKE_ARGS[@]}" .. || exit 1
 	    ${GMAKE} -j ${ACC_SET_GMAKE_JOBS} ${ACC_EXE_NAME}
 	    [ $? -eq 0 ] && func_display_build_time
 	fi


### PR DESCRIPTION
This adds `${CMAKE_ARGS}` to the cmake call in `util/mk-mkd`, which was previously implemented via a patch file: https://github.com/conda-forge/bmad-feedstock/blob/9f1efee5e209b0d18abda5d5dedcb742f43931be/recipe/0001-cmake_args.patch#L10C7-L10C95