### PR TITLE
Search for HDF5 include and library directories in Master.cmake

### DIFF
--- a/util/Master.cmake
+++ b/util/Master.cmake
@@ -558,6 +558,13 @@ SET (MASTER_LINK_DIRS
   ${ACC_LIB_DIRS}
 )
 
+foreach(h5dir ${HDF5_Fortran_LIBRARY_DIRS})
+  list(FIND CMAKE_Fortran_IMPLICIT_LINK_DIRECTORIES "${h5dir}" h5found)
+  if (h5found EQUAL -1)
+    list(APPEND MASTER_LINK_DIRS "${h5dir}")
+  endif()
+endforeach()
+
 IF (DEBUG)
   IF (IS_DIRECTORY "${PACKAGES_DIR}/debug/lib/root")
     LIST (APPEND MASTER_LINK_DIRS "${PACKAGES_DIR}/debug/lib/root")

--- a/util/Master.cmake
+++ b/util/Master.cmake
@@ -486,6 +486,15 @@ SET (MASTER_INC_DIRS
   ${X11_INCLUDE_DIR}
 )
 
+# If we use system HDF5 libraries, search for include directories
+find_package(HDF5 COMPONENTS Fortran)
+foreach(h5dir ${HDF5_Fortran_INCLUDE_DIRS})
+  list(FIND CMAKE_Fortran_IMPLICIT_INCLUDE_DIRECTORIES "${h5dir}" h5found)
+  if (h5found EQUAL -1)
+    list(APPEND MASTER_INC_DIRS "${h5dir}")
+  endif()
+endforeach()
+
 # If building for HARDWARE-DEVEL, remove the include directories which are not needed 
 
 IF (CMAKE_SYSTEM_NAME MATCHES "HARDWARE-DEVEL")


### PR DESCRIPTION
This is to support building with a system HDF5. Use CMake's built-in support for finding the HDF5 libraries, and add include and library directories if needed. Tested with an ordinary distribution build, and with system libraries on RH8, Ubuntu 22, and Arch. Can't necessarily use system HDF5 on RH7 since the module files may not be compatible with a newer compiler.