### PR TITLE
Put ${CMAKE_ARGS} first, so that debug works on conda-forge

### DIFF
--- a/util/mk-mkd
+++ b/util/mk-mkd
@@ -166,7 +166,7 @@ case ${@} in
 	        ACC_CMAKE_ARGS=()
 	    fi
 
-	    cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${CMAKE_ARGS} "${ACC_CMAKE_ARGS[@]}" .. || exit 1
+	    cmake ${CMAKE_ARGS} -DCMAKE_BUILD_TYPE=${BUILD_TYPE}  "${ACC_CMAKE_ARGS[@]}" .. || exit 1
 	    ${GMAKE} -j ${ACC_SET_GMAKE_JOBS} ${ACC_EXE_NAME}
 	    [ $? -eq 0 ] && func_display_build_time
 	fi


### PR DESCRIPTION
Conda-forge uses cmake `${CMAKE_ARGS}` to set the `BUILD_TYPE`, which confuses the Bmad debug build. This inverts the order so that the debug version is built. 