### PR TITLE
check for existing data before radiation_map_setup

### DIFF
--- a/bmad/modules/radiation_mod.f90
+++ b/bmad/modules/radiation_mod.f90
@@ -89,8 +89,10 @@ case (drift$, taylor$, multipole$, ab_multipole$, mask$, marker$);  return
 end select
 
 ! Use stochastic and damp mats
-
-call radiation_map_setup(ele)
+! Only setup if the element produces radiation and there isn't existing non-stale data
+if ((ele%value(l$) /= 0 .and. ele%key /= taylor$) .and. (.not. associated(ele%rad_map) .or. ele%rad_map%stale)) then
+  call radiation_map_setup(ele)
+endif
 
 if (edge == start_edge$) then
   rad_map = ele%rad_map%rm0


### PR DESCRIPTION
This is related to the performance issue in  #523. I think I was able to solve it by putting a check before where the `radiation_map_setup` subroutine is called.

Here is the performance on the example in the issue before the change.
```
Benchmark 1: tao -noplot -command exit
  Time (mean ± σ):      2.359 s ±  0.019 s    [User: 2.332 s, System: 0.024 s]
  Range (min … max):    2.336 s …  2.395 s    10 runs
```

Here is the performance with the checks.
```
Benchmark 1: tao -noplot -command exit
  Time (mean ± σ):      1.746 s ±  0.008 s    [User: 1.720 s, System: 0.023 s]
  Range (min … max):    1.736 s …  1.758 s    10 runs
```

It gives about a 25% reduction in running time for this example. Profiling it after the change confirms that the `radiation_map_setup` code takes an insignificant amount of time.
<img width="1325" alt="image" src="https://github.com/bmad-sim/bmad-ecosystem/assets/61094787/fcbd045e-9f8f-4748-80d8-1c6be8d3013b">
