### PR TITLE
Corrections to the Lynch-Dahl approximation of the multiple scattering sigma in the foil tracking code

### DIFF
--- a/bmad/low_level/track_a_foil.f90
+++ b/bmad/low_level/track_a_foil.f90
@@ -69,7 +69,6 @@ do ns = 1, n_step
       material => ele%foil%material(i)
       z_material = atomic_number(material%species)
       select case (nint(ele%value(scatter_method$)))
-
       case (highland$)
         xx0 = xx0 + r_thick * material%area_density_used / material%radiation_length_used
 
@@ -79,8 +78,7 @@ do ns = 1, n_step
         zza_sum = zza_sum + zza
         chi2_c = chi2_c + 0.157e11_rp * zza * r_thick * (z_particle / (pc_old * orbit%beta))**2
         ln_chi_alpha_sum = ln_chi_alpha_sum + zza * log(sqrt(2.007e7_rp * z_material**(2.0/3.0) * &
-             (1.0_rp + 3.34_rp * (z_material * z_particle * fine_structure_constant / orbit%beta)**2) / pc_old**2))
-
+                (1.0_rp + 3.34_rp * (z_material * z_particle * fine_structure_constant / orbit%beta)**2) / pc_old**2))
       end select
     enddo
 
@@ -91,24 +89,19 @@ do ns = 1, n_step
     endif
 
     select case (nint(ele%value(scatter_method$)))
-
     case (highland$)
       sigma = 13.6e6_rp * z_particle * sqrt(xx0) / (pc_old * orbit%beta) * &
-           (1.0_rp + 0.038_rp * log(xx0*z_particle**2/orbit%beta**2))
-
+                                          (1.0_rp + 0.038_rp * log(xx0*z_particle**2/orbit%beta**2))
     case (lynch_dahl$)
-       chi2_alpha = (exp(ln_chi_alpha_sum/zza_sum))**2
-       omega = chi2_c / (1.167 * chi2_alpha) 
-       nu = 0.5_rp * omega / (1 - f)
-       sigma = ( chi2_c * ((1 + nu) * log(1 + nu) / nu - 1) / (1 + f**2) )**(0.5_rp)
-      
+      chi2_alpha = (exp(ln_chi_alpha_sum/zza_sum))**2
+      omega = chi2_c / (1.167 * chi2_alpha) 
+      nu = 0.5_rp * omega / (1 - f)
+      sigma = (chi2_c * ((1 + nu) * log(1 + nu) / nu - 1) / (1 + f**2))**(0.5_rp)
     end select
     
     sigma = sigma * pc_old / orbit%p0c
-    
     orbit%vec(2) = orbit%vec(2) + rnd(1) * sigma
     orbit%vec(4) = orbit%vec(4) + rnd(2) * sigma
-    
   endif
 
   ! Energy loss

--- a/bmad/low_level/track_a_foil.f90
+++ b/bmad/low_level/track_a_foil.f90
@@ -69,6 +69,7 @@ do ns = 1, n_step
       material => ele%foil%material(i)
       z_material = atomic_number(material%species)
       select case (nint(ele%value(scatter_method$)))
+
       case (highland$)
         xx0 = xx0 + r_thick * material%area_density_used / material%radiation_length_used
 
@@ -76,9 +77,10 @@ do ns = 1, n_step
         atomic_mass = mass_of(material%species) / atomic_mass_unit
         zza = z_material * (z_material + 1) * material%area_density_used  / atomic_mass
         zza_sum = zza_sum + zza
-        chi2_c = chi2_c + 0.157e7_rp * zza * r_thick * (z_particle / (pc_old * orbit%beta))**2
-        ln_chi_alpha_sum = ln_chi_alpha_sum + zza * log(sqrt(2.007e1_rp * z_material**(2.0/3.0) * &
-                (1.0_rp + 3.34_rp * (z_material * z_particle * fine_structure_constant / orbit%beta)**2) / pc_old**2))
+        chi2_c = chi2_c + 0.157e11_rp * zza * r_thick * (z_particle / (pc_old * orbit%beta))**2
+        ln_chi_alpha_sum = ln_chi_alpha_sum + zza * log(sqrt(2.007e7_rp * z_material**(2.0/3.0) * &
+             (1.0_rp + 3.34_rp * (z_material * z_particle * fine_structure_constant / orbit%beta)**2) / pc_old**2))
+
       end select
     enddo
 
@@ -89,19 +91,24 @@ do ns = 1, n_step
     endif
 
     select case (nint(ele%value(scatter_method$)))
+
     case (highland$)
       sigma = 13.6e6_rp * z_particle * sqrt(xx0) / (pc_old * orbit%beta) * &
-                                          (1.0_rp + 0.038_rp * log(xx0*z_particle**2/orbit%beta**2))
-    case (lynch_dahl$)
-      chi2_alpha = (exp(ln_chi_alpha_sum/zza_sum))**2
-      omega = chi2_c / (1.167 * chi2_alpha) 
-      nu = 0.5_rp * omega / (1.167 * (1 + f))
-      sigma = chi2_c * ((1 + nu) * log(1 + nu) / nu - 1) / (1 + f**2)
-    end select
+           (1.0_rp + 0.038_rp * log(xx0*z_particle**2/orbit%beta**2))
 
+    case (lynch_dahl$)
+       chi2_alpha = (exp(ln_chi_alpha_sum/zza_sum))**2
+       omega = chi2_c / (1.167 * chi2_alpha) 
+       nu = 0.5_rp * omega / (1 - f)
+       sigma = ( chi2_c * ((1 + nu) * log(1 + nu) / nu - 1) / (1 + f**2) )**(0.5_rp)
+      
+    end select
+    
     sigma = sigma * pc_old / orbit%p0c
+    
     orbit%vec(2) = orbit%vec(2) + rnd(1) * sigma
     orbit%vec(4) = orbit%vec(4) + rnd(2) * sigma
+    
   endif
 
   ! Energy loss


### PR DESCRIPTION
I made some corrections to the calculation of the Lynch-Dahl scattering sigma:

1.  The factor $0.157$ in the expression for `chi2_c`, as defined in the 1991 Lynch-Dahl paper, should be multiplied by $10^{11}$ rather than $10^{7}$. This is to facilitate the conversion of `kg/m^2` to `g/cm^2` and `1/eV^2` to `1/MeV^2`. 
2. The factor $2.007\times10^{-5}$ in the expression for `chi2_alpha` should be multiplied by $10^{12}$, in order to convert to `1/eV^2` to `1/MeV^2`. This makes it $2.007\times10^{7}$ rather than $2.007\times10^{1}$.
3. The expression for `nu` should be `nu = 0.5_rp * omega / (1 - f)` rather than `nu = 0.5_rp * omega / (1.167 * (1 + f))` -- the factor of `1/1.167` comes in during the calculation of `omega` and we need a `-f` rather than a `+f`. 
4. The `sigma` stated in the paper is really `sigma^2`: I added a square root. 

With these changes I get values of sigma consistent with those found using the Rossi-Greisen and Highland approximations, as well as G4beamline (Geant4.10). 

More testing is needed, though!

Thanks,
Sam

