### PR TITLE
On MacOS, respect the user's setting of CC

### DIFF
--- a/util/acc_build_common
+++ b/util/acc_build_common
@@ -206,7 +206,12 @@ func_check_macports () {
     fi
 
     if ( [ `uname` == "Darwin" ] ) ; then
-      if ( [ "$(type gcc &> /dev/null ; echo $?)" -eq 0 ] ) ; then
+      if [ -n "$CC" ]
+      then
+	  echo "User specified CC=$CC"
+	  [ -n "$CXX" ] && echo "User specified CXX=$CXX"
+	  [ -n "$FC" ] && echo "User specified FC=$FC"
+      elif ( [ "$(type gcc &> /dev/null ; echo $?)" -eq 0 ] ) ; then
           export VER=$(uname -r | cut -d. -f1)
           export GCC_PATH=$(type gcc | cut -d" " -f3)
           if ( [ "${GCC_PATH}" != "/usr/local/bin/gcc" ] ) ; then


### PR DESCRIPTION
For HomeBrew, the right thing to do is for the user to set CC=gcc-## and CXX=g++-##, and have the build system actually use those for building. This allows that to work, without this the build system tries to find gcc in the expected location and fails unless the links in the offsite instructions have been made. I'm not sure we should be advising people to make those links; HomeBrew's installation system (which often will build a package) is designed to work with the compiler being Apple's; I've seen advice not to make the link, but I can't find anything in the documentation explicitly forbidding the user to do that (though it is clearly not the default behavior).