### PR TITLE
Use DYLD_FALLBACK_LIBRARY_PATH instead of DYLD_LIBRARY_PATH on mac

### DIFF
--- a/util/dist_source_me
+++ b/util/dist_source_me
@@ -366,14 +366,14 @@ func_add_bmad_path () {
     else
         export LD_LIBRARY_PATH=${BMAD_LIB_PROD_PATH}:${BMAD_LIB_DEBUG_PATH}
 
-        # Configure DYLD_LIBRARY_PATH for Mac OS X
+        # Configure DYLD_FALLBACK_LIBRARY_PATH for Mac OS X
         if [ "${DIST_OS}" == "Darwin" ] ; then
 
             if ( [ "${DIST_F90_REQUEST}" == "ifort" ] && [ -d /opt/intel/lib ] ) ; then
-                export DYLD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/intel/lib
+                export DYLD_FALLBACK_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/intel/lib
 
             elif [ -d /opt/local/lib ] ; then
-                export DYLD_LIBRARY_PATH=${LD_LIBRARY_PATH}
+                export DYLD_FALLBACK_LIBRARY_PATH=${LD_LIBRARY_PATH}
             fi
         fi
     fi


### PR DESCRIPTION
Using DYLD_LIBRARY_PATH can cause problems with symbol loading when more than 1 library exists on the machine. This is what caused the problem I had with Julia FFTW being unable to load, because of the different compilation settings used vs Bmad's.

[See this answer for more details](https://stackoverflow.com/questions/3146274/is-it-ok-to-use-dyld-library-path-on-mac-os-x-and-whats-the-dynamic-library-s)