### PR TITLE
Rename sigma_cutoff -> ldc_sigma_cutoff in CSR regression test

### DIFF
--- a/regression_tests/python_test/csr_beam_tracking/CSR.tao
+++ b/regression_tests/python_test/csr_beam_tracking/CSR.tao
@@ -15,7 +15,7 @@ set space_charge_com n_shield_images = 0
 set space_charge_com ds_track_step = 0.01
 set space_charge_com n_bin = 40
 set space_charge_com particle_bin_span = 2
-
+set space_charge_com lsc_sigma_cutoff = 0.1 ! Cutoff for the lsc calc. If a bin sigma is < cutoff * sigma_ave then ignore.
 set space_charge_com%diagnostic_output_file  = "wake.txt"
 
 set ele * csr_method = 1_dim

--- a/regression_tests/python_test/csr_beam_tracking/CSR.tao
+++ b/regression_tests/python_test/csr_beam_tracking/CSR.tao
@@ -15,8 +15,6 @@ set space_charge_com n_shield_images = 0
 set space_charge_com ds_track_step = 0.01
 set space_charge_com n_bin = 40
 set space_charge_com particle_bin_span = 2
-set space_charge_com sigma_cutoff = 0.1 ! Cutoff for the lsc calc. If a bin sigma is < cutoff * sigma_ave then ignore.
-!set space_charge_com write_csr_wake = T
 
 set space_charge_com%diagnostic_output_file  = "wake.txt"
 


### PR DESCRIPTION
This fixes a line from `regression_tests/python_test/csr_beam_tracking/CSR.tao`