### PR TITLE
Add "ix_ele" to Python `bunch1` Command

### DIFF
--- a/regression_tests/python_test/csr_beam_tracking/CSR.tao
+++ b/regression_tests/python_test/csr_beam_tracking/CSR.tao
@@ -15,7 +15,7 @@ set space_charge_com n_shield_images = 0
 set space_charge_com ds_track_step = 0.01
 set space_charge_com n_bin = 40
 set space_charge_com particle_bin_span = 2
-set space_charge_com sigma_cutoff = 0.1 ! Cutoff for the lsc calc. If a bin sigma is < cutoff * sigma_ave then ignore.
+set space_charge_com lsc_sigma_cutoff = 0.1 ! Cutoff for the lsc calc. If a bin sigma is < cutoff * sigma_ave then ignore.
 !set space_charge_com write_csr_wake = T
 
 set space_charge_com%diagnostic_output_file  = "wake.txt"

--- a/tao/code/tao_python_cmd.f90
+++ b/tao/code/tao_python_cmd.f90
@@ -749,7 +749,7 @@ case ('bunch_params')
 !   {ele_id} is an element name or index.
 !   {which} is one of: "model", "base" or "design"
 !   {ix_bunch} is the bunch index.
-!   {coordinate} is one of: x, px, y, py, z, pz, "s", "t", "charge", "p0c", "state"
+!   {coordinate} is one of: x, px, y, py, z, pz, "s", "t", "charge", "p0c", "state", "ix_ele"
 !
 ! For example, if {coordinate} = "px", the phase space px coordinate of each particle
 ! of the bunch is displayed. The "state" of a particle is an integer. A value of 1 means
@@ -8310,7 +8310,9 @@ case ('p0c')
 case ('state')
   call reallocate_c_integer_scratch(n)
   tao_c_interface_com%c_integer(1:n) = bunch%particle(:)%state
-
+case ('ix_ele')
+  call reallocate_c_integer_scratch(n)
+  tao_c_interface_com%c_integer(1:n) = bunch%particle(:)%ix_ele
 case default
   call invalid ('coordinate not "x", "px", etc. ')
   return

--- a/util/dist_prefs
+++ b/util/dist_prefs
@@ -124,7 +124,7 @@ export ACC_ENABLE_GFORTRAN_OPTIMIZATION="Y"
 # ACC_ENABLE_SHARED_ONLY must set to "N" if
 # ACC_ENABLE_SHARED is set to "Y"
 #-----------------------------------------------------------
-export ACC_ENABLE_SHARED="N"
+export ACC_ENABLE_SHARED="Y"
 
 
 #-----------------------------------------------------------
@@ -138,7 +138,7 @@ export ACC_ENABLE_SHARED="N"
 # ACC_ENABLE_SHARED must be set to "N", if 
 # ACC_ENABLE_SHARED_ONLY is set to "Y"
 #-----------------------------------------------------------
-export ACC_ENABLE_SHARED_ONLY="Y"
+export ACC_ENABLE_SHARED_ONLY="N"
 
 
 #-----------------------------------------------------------
@@ -152,7 +152,7 @@ export ACC_ENABLE_SHARED_ONLY="Y"
 # shared libraries (.so files ) but will not explicitly 
 # enable -fPIC in static libraries (.a files).
 #-----------------------------------------------------------
-export ACC_ENABLE_FPIC="Y"
+export ACC_ENABLE_FPIC="N"
 
 
 #-----------------------------------------------------------
@@ -162,7 +162,7 @@ export ACC_ENABLE_FPIC="Y"
 # compilations using that number of CPU cores.  The default 
 # value is "2" and cannot be set lower than "1"
 #-----------------------------------------------------------
-export ACC_SET_GMAKE_JOBS="4"
+export ACC_SET_GMAKE_JOBS="8"
 
 
 #-----------------------------------------------------------
@@ -181,3 +181,5 @@ export ACC_CONDA_BUILD="N"
 # environment.
 #-----------------------------------------------------------
 export ACC_CONDA_PATH="${CONDA_PREFIX}"
+
+export BMAD_MAC_PACKAGE="macports"

--- a/util/dist_prefs
+++ b/util/dist_prefs
@@ -124,7 +124,7 @@ export ACC_ENABLE_GFORTRAN_OPTIMIZATION="Y"
 # ACC_ENABLE_SHARED_ONLY must set to "N" if
 # ACC_ENABLE_SHARED is set to "Y"
 #-----------------------------------------------------------
-export ACC_ENABLE_SHARED="Y"
+export ACC_ENABLE_SHARED="N"
 
 
 #-----------------------------------------------------------
@@ -138,7 +138,7 @@ export ACC_ENABLE_SHARED="Y"
 # ACC_ENABLE_SHARED must be set to "N", if 
 # ACC_ENABLE_SHARED_ONLY is set to "Y"
 #-----------------------------------------------------------
-export ACC_ENABLE_SHARED_ONLY="N"
+export ACC_ENABLE_SHARED_ONLY="Y"
 
 
 #-----------------------------------------------------------
@@ -152,7 +152,7 @@ export ACC_ENABLE_SHARED_ONLY="N"
 # shared libraries (.so files ) but will not explicitly 
 # enable -fPIC in static libraries (.a files).
 #-----------------------------------------------------------
-export ACC_ENABLE_FPIC="N"
+export ACC_ENABLE_FPIC="Y"
 
 
 #-----------------------------------------------------------
@@ -162,7 +162,7 @@ export ACC_ENABLE_FPIC="N"
 # compilations using that number of CPU cores.  The default 
 # value is "2" and cannot be set lower than "1"
 #-----------------------------------------------------------
-export ACC_SET_GMAKE_JOBS="8"
+export ACC_SET_GMAKE_JOBS="4"
 
 
 #-----------------------------------------------------------
@@ -181,5 +181,3 @@ export ACC_CONDA_BUILD="N"
 # environment.
 #-----------------------------------------------------------
 export ACC_CONDA_PATH="${CONDA_PREFIX}"
-
-export BMAD_MAC_PACKAGE="macports"


### PR DESCRIPTION
This PR adds "ix_ele" as one of the valid coordinates to the `bunch1` command. This enables users of pytao to load the locations of particle loss after tracking. Also changed was renaming `sigma_cutoff` to `lsc_sigma_cutoff` in one of the regression tests which was causing a pytao test to fail.

I have tested the code by compiling it on my machine and running it with a version of pytao which can load this coordinate. The data seems to be loaded correctly when compared with `sho particle -ele ... -all -lost`.