### PR TITLE
Remove unnecessary macports/homebrew checking in acc_build_common

### DIFF
--- a/util/acc_build_common
+++ b/util/acc_build_common
@@ -192,72 +192,6 @@ func_set_fpic_flags () {
 
 }
 
-# Function to check for required MacPorts install on Mac OS X
-
-func_check_macports () {
-    # We don't need MacPorts for CONDA builds
-    if ( [[ "${CONDA_BUILD}" ]] ) ; then
-           return
-    fi
-
-    # We don't need MacPorts if not using it
-    if ( [[ ! "${USE_MACPORTS}" ]] ) ; then
-           return
-    fi
-
-    if ( [ `uname` == "Darwin" ] ) ; then
-      if [ -n "$CC" ]
-      then
-	  echo "User specified CC=$CC"
-	  [ -n "$CXX" ] && echo "User specified CXX=$CXX"
-	  [ -n "$FC" ] && echo "User specified FC=$FC"
-      elif ( [ "$(type gcc &> /dev/null ; echo $?)" -eq 0 ] ) ; then
-          export VER=$(uname -r | cut -d. -f1)
-          export GCC_PATH=$(type gcc | cut -d" " -f3)
-          if ( [ "${GCC_PATH}" != "/usr/local/bin/gcc" ] ) ; then
-            if ( [ "${VER}" -gt 11 ] && [ ! -d "/opt/local/etc/macports" ] ) ; then 
-                echo -e \
-                   "\nSince gcc is not installed at /usr/local/bin/gcc, I'm assuming you are using MacPorts..." \
-                   "\nCan't find GNU GCC, please install MacPorts, using instructions on:" \
-                   "\n\n    http://www.macports.org/install.php" \
-                   "\n\nThen follow instructions on:" \
-                   "\n\n    ${ACC_LIB_TOOLS_WIKI}\n"
-                exit 69
-            elif [ ! -L /opt/local/bin/gcc ] ; then
-                echo -e \
-                   "\nSince gcc is not installed at /usr/local/bin/gcc, I'm assuming you are using MacPorts..." \
-                   "\nBut! No selected MacPorts gcc version is found!" \
-                   "\n\nPlease follow instructions on:" \
-                "\n\n    ${ACC_LIB_TOOLS_WIKI}\n"
-                exit 70
-            elif ( [ "${GCC_PATH}" == "/usr/bin/gcc" ] && [ -d "/opt/local/etc/macports" ] ) ; then
-                echo -e \
-                   "\nSince gcc is not installed at /usr/local/bin/gcc, I'm assuming you are using MacPorts..." \
-                   "\nBut! MacPorts gcc is not in your PATH..." \
-                   "\nPlease add the following line to the bottom of your ~/.bash_profile or ~/.bashrc file:" \
-                   "\n\n    export PATH=/opt/local/bin:/opt/local/sbin:\$PATH" \
-                   "\n\nThen logout and log back in, cd into the Bmad distribution folder and" \
-                   "\nreinitialize the Bmad Environment using:" \
-                   "\n\n    source util/dist_source_me\n"
-                exit 78
-            elif [ "${GCC_PATH}" == "/opt/local/bin/gcc" ] ; then
-                export CC=gcc
-            fi
-          elif ( [ "${GCC_PATH}" == "/usr/local/bin/gcc" ] ) ; then
-            export CC=gcc
-          fi
-      else
-          echo -e \
-             "\nCan't find GCC, please install Xcode and MacPorts, using instructions on:" \
-             "\n\n    http://www.macports.org/install.php:" \
-             "\n\nThen follow instructions on:" \
-             "\n\n    ${ACC_LIB_TOOLS_WIKI}\n"
-          exit 69
-      fi
-    fi
-}
-
-     
 #-----------------------------------------------------------------
 # Function to check for Fortran. If gfortran or ifort is 
 # requested, check for the specified minimum version
@@ -594,10 +528,6 @@ func_install_utilities () {
 
           if [ ${STATUS} -eq 0 ] ; then
 
-            if ( [ `uname` == "Darwin" ] ) ; then
-                func_check_macports
-            fi
-            
             [ ${UTIL_NAME} == "pkg-config" ] \
                 && UTIL_INSTALLED_VERSION=$(${UTIL_NAME} --version) \
                 || UTIL_INSTALLED_VERSION=$(${UTIL_NAME} --version | head -1 | awk ' { print $4 } ')
@@ -776,11 +706,6 @@ case "${ACC_CONDA_BUILD}" in
         CONDA_BUILD=1
         ;;
 esac
-case "${ACC_USE_MACPORTS}" in
-    "Y" | "y" | "1" )
-        USE_MACPORTS=1
-        ;;
-esac
 
 if ( [ "${1}" == "-debug" ] || [ "${1}" == "-production" ] ) ; then
 
@@ -821,7 +746,6 @@ if ( [ "${1}" == "-debug" ] || [ "${1}" == "-production" ] ) ; then
       func_set_gmake_job_level
       func_set_openmp_flags
       func_set_fpic_flags
-      func_check_macports
       func_check_fortran_version
       func_set_c_flags
         func_set_fortran_flags


### PR DESCRIPTION
Clean out MacPorts detection from `util/acc_build_common` since it's now done elsewhere. `ACC_USE_MACPORTS` no longer used or needed.