### PR TITLE
Update dark current tracker

### DIFF
--- a/bsim/dark_current_tracker/dark_current_mod.f90
+++ b/bsim/dark_current_tracker/dark_current_mod.f90
@@ -223,7 +223,7 @@ if (g_frame) then
       !Write lines with E and B fields. Use w_mat to rotate the field vectors into the global frame
       do point_id = 0, track%n_pt
         orb = particle_in_global_frame(track%pt(point_id)%orb, branch, w_mat_out = w_mat)
-        write (outfile, '(15es19.10E3)') &
+        write (outfile, '(15es26.17E3)') &
         orb%vec(1:6),&
         orb%t, &
         orb%charge, &

--- a/bsim/dark_current_tracker/dark_current_tracker.f90
+++ b/bsim/dark_current_tracker/dark_current_tracker.f90
@@ -42,7 +42,7 @@ type (dark_current_param_struct) :: dc_param
 type (dark_current_param_struct), allocatable :: omp_dc_param(:)
 type (dark_current_tally_struct), allocatable :: tally(:)
 
-character(100) :: in_file, lat_name, lat2_name, lat_path, base_name, particle_file_name, monitor_file_name, outfile_name
+character(2000) :: in_file, lat_name, lat2_name, lat_path, base_name, particle_file_name, monitor_file_name, outfile_name
 character(400) :: element_monitor_list
 real(rp) :: e_tot, max_charge, min_charge_ratio, dt_save
 real(rp) :: color
@@ -147,6 +147,14 @@ print *, 'particle_file_name: ', trim(dc_param%particle_file_name)
 
 ! Force saving tracks with plot
 if (dc_param%plot_on) dc_param%save_tracks = .true.
+
+
+if ((.not. save_tracks) .and. save_field) then
+  call out_io (s_warn$, r_name, 'WARNING: save_field only allowed with save_tracks. Disabling save_field')
+  !print *, 'WARNING: save_field only allowed with save_tracks. Disabling save_field'
+   dc_param%save_field = .false.
+   save_field = .false.
+endif
 
 
 if (rel_tol_adaptive_tracking /= bmad_com%rel_tol_adaptive_tracking) then


### PR DESCRIPTION
This extends the filename length for the dark_current_tracker to 2000 characters, and extends the precision of particle data output. 