### PR TITLE
Correct calc_super_slave_key logic for an sbend superimposed on a drift.

### DIFF
--- a/bmad/low_level/calc_super_slave_key.f90
+++ b/bmad/low_level/calc_super_slave_key.f90
@@ -39,16 +39,15 @@ key2 = lord2%key
 slave%key = -1  ! Default if no superimpose possible
 slave%sub_key = 0
 
-! * If one element is a drift then slave%key = key of other element.
-! * Control elements, etc. cannot be superimposed.
-
+! If one element is a drift then slave%key = key of other element.
+! Control elements, naturally zero length elements, etc. cannot be superimposed upon
 
 select case (key1)
-case (overlay$, group$, girder$, taylor$, match$, patch$, fiducial$, floor_shift$, multipole$, ab_multipole$, sbend$, rf_bend$); return
+case (overlay$, group$, ramper$, girder$, taylor$, match$, patch$, fiducial$, floor_shift$, multipole$, ab_multipole$); return
 end select
 
 select case (key2)
-case (overlay$, group$, girder$, taylor$, match$, patch$, fiducial$, floor_shift$, multipole$, ab_multipole$, sbend$, rf_bend$); return
+case (overlay$, group$, ramper$, girder$, taylor$, match$, patch$, fiducial$, floor_shift$, multipole$, ab_multipole$); return
 end select
 
 select case (key1)
@@ -65,6 +64,8 @@ case (drift$, pipe$)
   slave%sub_key = lord1%sub_key
   return
 end select
+
+if (key1 == sbend$ .or. key1 == rf_bend$ .or. key2 == sbend$ .or. key2 == rf_bend$) return
 
 ! If there are misalignments then no superposition is possible
 
@@ -89,8 +90,6 @@ endif
 
 if (key1 == key2) then
   select case (key1)
-  case (sbend$)
-    ! Bad
   case (rfcavity$, wiggler$, undulator$)
     slave%key = em_field$
     slave%value(constant_ref_energy$) = true$

--- a/tao/version/tao_version_mod.f90
+++ b/tao/version/tao_version_mod.f90
@@ -6,5 +6,5 @@
 !-
 
 module tao_version_mod
-character(*), parameter :: tao_version_date = "2024/05/10 15:23:35"
+character(*), parameter :: tao_version_date = "2024/05/25 17:37:46"
 end module


### PR DESCRIPTION
Correct calc_super_slave_key logic for an sbend superimposed on a drift.