### PR TITLE
ADST show in phasors basis in show spin

### DIFF
--- a/tao/code/tao_show_this.f90
+++ b/tao/code/tao_show_this.f90
@@ -854,7 +854,7 @@ case ('chromaticity')
     z1 =  real(ptc_nf%phase(1) .sub. expo)
     z2 =  real(ptc_nf%phase(2) .sub. expo)
     if (i == 0) then
-      nl=nl+1; write (lines(nl), '(i3, 2es18.7, a)') i, z1, z2 '  ! 0th order are the tunes'
+      nl=nl+1; write (lines(nl), '(i3, 2es18.7, a)') i, z1, z2, '  ! 0th order are the tunes'
     else
       nl=nl+1; write (lines(nl), '(i3, 2es18.7)') i, z1, z2
     endif
@@ -4552,7 +4552,7 @@ case ('spin')
     ptc_nf  => tao_branch%ptc_normal_form
     ctaylor1 = ptc_nf%spin_tune
 
-    call type_complex_taylors(ctaylor1, out_type = 'NONE')
+    call type_complex_taylors([ctaylor1], out_type = 'NONE')
     return   
   endif
 

--- a/tao/code/tao_show_this.f90
+++ b/tao/code/tao_show_this.f90
@@ -103,7 +103,7 @@ type (track_struct), target :: track
 type (track_point_struct), pointer :: tp
 type (strong_beam_struct), pointer :: sb
 type (c_taylor) ptc_ctaylor
-type (complex_taylor_struct) bmad_ctaylor, ctaylor(3)
+type (complex_taylor_struct) bmad_ctaylor, ctaylor(3), ctaylor1
 type (rad_map_ele_struct), pointer :: ri
 type (grid_field_pt1_struct), pointer :: g_pt
 type (tao_expression_info_struct), allocatable :: info(:)
@@ -847,19 +847,16 @@ case ('chromaticity')
   ptc_nf  => tao_branch%ptc_normal_form
 
   nl=nl+1; lines(nl) = '  Note: Calculation is done with RF off.'
-  nl=nl+1; lines(nl) = '  N     chrom_ptc.a.N     chrom_ptc.b.N   spin_tune_ptc.N'
+  nl=nl+1; lines(nl) = '  N     chrom_ptc.a.N     chrom_ptc.b.N'
 
   do i = 0, ptc_private%taylor_order_ptc-1
     expo = [0, 0, 0, 0, 0, i]
     z1 =  real(ptc_nf%phase(1) .sub. expo)
     z2 =  real(ptc_nf%phase(2) .sub. expo)
-    s0 = real(ptc_nf%spin_tune .sub. expo)
     if (i == 0) then
-      nl=nl+1; write (lines(nl), '(i3, 3es18.7, a)') i, z1, z2, s0, '  ! 0th order are the tunes'
-    elseif (i == 1 .and. .not. bmad_com%spin_tracking_on) then
-      nl=nl+1; write (lines(nl), '(i3, 3es18.7, a)') i, z1, z2, s0, '  ! Spin tracking off so spin tune not calculated'
+      nl=nl+1; write (lines(nl), '(i3, 2es18.7, a)') i, z1, z2 '  ! 0th order are the tunes'
     else
-      nl=nl+1; write (lines(nl), '(i3, 3es18.7)') i, z1, z2, s0
+      nl=nl+1; write (lines(nl), '(i3, 2es18.7)') i, z1, z2
     endif
   enddo
 
@@ -878,12 +875,9 @@ case ('chromaticity')
   if (what_to_show == '-taylor') then
     call alloc(ptc_ctaylor)
 
-    do i = 1, 4
-      if (i == 4) then
-        ptc_ctaylor = ptc_nf%spin_tune * ci_phasor() * ptc_nf%normal_form%atot**(-1)
-      else
-        ptc_ctaylor = ptc_nf%phase(i) * ci_phasor() * ptc_nf%normal_form%atot**(-1)
-      endif
+    do i = 1, 3
+        ! ptc_ctaylor = ptc_nf%spin_tune * ci_phasor() * ptc_nf%normal_form%atot**(-1)
+      ptc_ctaylor = ptc_nf%phase(i) * ci_phasor() * ptc_nf%normal_form%atot**(-1)
       bmad_ctaylor = ptc_ctaylor
       nl=nl+1; lines(nl) = ''
       nl=nl+1; lines(nl) = 'Taylor series: ' // trim(mode(i)) // ' tune'
@@ -892,9 +886,9 @@ case ('chromaticity')
       lines(nl+1:nl+n) = alloc_lines(1:n)
       nl = nl + n
 
-      if (i == 4 .and. .not. associated(bmad_ctaylor%term) .and. .not. bmad_com%spin_tracking_on) then
-        nl=nl+1; lines(nl) = 'Spin tracking is turned on with: "set bmad_com spin_tracking_on = T".'
-      endif
+      !if (i == 4 .and. .not. associated(bmad_ctaylor%term) .and. .not. bmad_com%spin_tracking_on) then
+      !  nl=nl+1; lines(nl) = 'Spin tracking is turned on with: "set bmad_com spin_tracking_on = T".'
+      !endif
     enddo
 
     call kill(ptc_ctaylor)
@@ -4463,7 +4457,7 @@ case ('spin')
   do
     call tao_next_switch (what2, [character(24):: '-element', '-n_axis', '-l_axis', &
                             '-g_map', '-flip_n_axis', '-x_zero', '-y_zero', &
-                            '-z_zero', '-ignore_kinetic', '-isf'], .true., switch, err)
+                            '-z_zero', '-ignore_kinetic', '-isf', '-spin_tune'], .true., switch, err)
     if (err) return
 
     select case (switch)
@@ -4483,6 +4477,8 @@ case ('spin')
       flip = .true.
     case ('-isf')
       what_to_show = 'isf'
+    case ('-spin_tune')
+      what_to_show = 'spin_tune'
     case ('-n_axis')
       read (what2, *, iostat = ios) sm%axis_input%n0
       if (ios /= 0) then
@@ -4542,6 +4538,22 @@ case ('spin')
 
     call type_complex_taylors(ctaylor, out_type = 'SPIN')
     return
+  endif
+  
+  if (what_to_show == 'spin_tune') then
+    if (branch%param%geometry == open$) then
+      nl=nl+1; lines(nl) = 'No spin tune for an open lattice!'
+      return
+    endif
+
+    tao_branch%spin_map_valid = .false.
+    if (.not. u%calc%one_turn_map) call tao_ptc_normal_form (.true., u%model, branch%ix_branch)
+
+    ptc_nf  => tao_branch%ptc_normal_form
+    ctaylor1 = ptc_nf%spin_tune
+
+    call type_complex_taylors(ctaylor1, out_type = 'NONE')
+    return   
   endif
 
   ! what_to_show = standard

--- a/tao/doc/command-list.tex
+++ b/tao/doc/command-list.tex
@@ -2108,8 +2108,8 @@ is momentum compaction and phase slip and derivatives.
 If no universe is given, the current default universe (\sref{s:universe}) is used.
 
 The \vn{-taylor} switch will show the Taylor series for the three normal mode tunes as functions 
-of the phase space coordinates. The computation uses complex series. The imaginary part should be 
-zero (or very small).
+of the phase space coordinates. The computation uses complex series. The imaginary part should 
+be zero (or very small).
 
 
 %% show constraints --------------------------------------------------------------
@@ -3068,9 +3068,9 @@ for the three components of the spin $(S_x, S_y, S_z)$. The independent variable
 phase space coordinates $(x, p_x, y, p_y, z, p_z)$.
 
 The \vn{-spin_tune} switch, if present, will print the amplitude-dependent spin tune. The output will 
-be a Taylor series in the phasor's basis, i.e. $x_{\pm k} = \sqrt{J_k}\exp{\pm i\phi_k}$. For example 
-the monomial ``[1 1 0 0 0 0]'' corresponds to $J_a$, and ``[1 1 2 2 3 3]'' corresponds to 
-$J_aJ_b^2J_c^3$.
+be a Taylor series in the phasor's basis, i.e. $x_k = sqrt(J_k)*exp(i*phi_k)$. For example the 
+monomial ``[1 1 0 0 0 0]'' corresponds to $J_a$, and if RF is on then ``[1 1 2 2 3 3]'' corresponds 
+to $J_a*J_b^2*J_c^3$.
 
 The \vn{-x_zero}, \vn{-y_zero}, and \vn{-z_zero} options are for testing if supressing certain terms
 in the linear part of the spin transport map for a set of elements selected by the user will

--- a/tao/doc/command-list.tex
+++ b/tao/doc/command-list.tex
@@ -2107,9 +2107,9 @@ is momentum compaction and phase slip and derivatives.
 
 If no universe is given, the current default universe (\sref{s:universe}) is used.
 
-The \vn{-taylor} switch will show the Taylor series for the three normal mode tunes and spin tune
-as functions of the phase space coordinates. The computation uses complex series. The imaginary part
-should be zero (or very small). The spin Taylor series is only computed when spin tracking is on.
+The \vn{-taylor} switch will show the Taylor series for the three normal mode tunes as functions 
+of the phase space coordinates. The computation uses complex series. The imaginary part should be 
+zero (or very small).
 
 
 %% show constraints --------------------------------------------------------------
@@ -3013,7 +3013,7 @@ Examples:
 Syntax:
 \begin{example}
   show spin \{-element \{<ref_ele_name>\} <ele_name>\} \{-flip_n_axis\} \{-g_map\}
-                  \{-ignore_kinetic <ele_list>\} \{-isf\}
+                  \{-ignore_kinetic <ele_list>\} \{-isf\} \{-spin_tune\}
                   \{-l_axis <lx>, <ly>, <lz>\} \{-n_axis <nx>, <ny>, <nz>\} 
                   \{-x_zero <ele_list>\} \{-y_zero <ele_list>\} \{-z_zero <ele_list>\}
 \end{example}
@@ -3066,6 +3066,11 @@ The \vn{-flip_n_axis} switch, if present, will flip the direction of the display
 The \vn{-isf} switch, if present, will print the invariant spin field which are three taylor series
 for the three components of the spin $(S_x, S_y, S_z)$. The independent variables are the six orbital
 phase space coordinates $(x, p_x, y, p_y, z, p_z)$.
+
+The \vn{-spin_tune} switch, if present, will print the amplitude-dependent spin tune. The output will 
+be a Taylor series in the phasor's basis, i.e. $x_{\pm k} = \sqrt{J_k}\exp{\pm i\phi_k}$. For example 
+the monomial ``[1 1 0 0 0 0]'' corresponds to $J_a$, and ``[1 1 2 2 3 3]'' corresponds to 
+$J_aJ_b^2J_c^3$.
 
 The \vn{-x_zero}, \vn{-y_zero}, and \vn{-z_zero} options are for testing if supressing certain terms
 in the linear part of the spin transport map for a set of elements selected by the user will


### PR DESCRIPTION
I've removed the spin tune output in show taylor and placed it in show spin with the flag `-spin_tune`, also now printed in the phasors basis. I haven't tested if this works yet because of Bmad dependency compile bugs