### PR TITLE
Detect HomeBrew properly on Intel Macs

### DIFF
--- a/util/Master.cmake
+++ b/util/Master.cmake
@@ -338,9 +338,10 @@ IF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND NOT $ENV{ACC_CONDA_BUILD} MATCHES 
     endif()
   endif()
   if (DO_BREW)
-    # Assuming an ARM mac here, path is different for an x86 Mac
-    set(ACC_INC_DIRS ${ACC_INC_DIRS} /opt/homebrew/include /opt/homebrew/opt/readline/include)
-    set(ACC_LIB_DIRS ${ACC_LIB_DIRS} /opt/homebrew/lib /opt/homebrew/opt/readline/lib)
+    execute_process(COMMAND "brew" "--prefix" OUTPUT_VARIABLE HOMEBREW_PREFIX)
+    string(STRIP "${HOMEBREW_PREFIX}" HOMEBREW_PREFIX)
+    set(ACC_INC_DIRS ${ACC_INC_DIRS} "${HOMEBREW_PREFIX}/include" "${HOMEBREW_PREFIX}/opt/readline/include")
+    set(ACC_LIB_DIRS ${ACC_LIB_DIRS} "${HOMEBREW_PREFIX}/lib" "${HOMEBREW_PREFIX}/opt/readline/lib")
   elseif (DO_PORT)
     set(ACC_INC_DIRS ${ACC_INC_DIRS} /opt/local/include)
     set(ACC_LIB_DIRS ${ACC_LIB_DIRS} /opt/local/lib)

--- a/util/dist_source_me
+++ b/util/dist_source_me
@@ -414,7 +414,7 @@ func_macos_gcc () {
 	    fi
 	elif [ "$brew" ]
 	then
-	    p=/opt/homebrew/bin/gcc-
+	    p=$(brew --prefix)/bin/gcc-
 	    v=0
 	    for g in $p[0-9]*
 	    do


### PR DESCRIPTION
Homebrew installs at different locations on Intel and ARM Macs. Now I use "brew --prefix" to detect HomeBrew prefix rather than hardcoding the ARM version. Should hopefully work properly on Intel macs now, but all I can test is that it doesn't break the ARM build...
