### PR TITLE
Fix so ramper elements where no slave has the attribute to be controlled generates an error message.

### DIFF
--- a/bmad-doc/tutorial_bmad_tao/doc/tutorial_bmad_tao.tex
+++ b/bmad-doc/tutorial_bmad_tao/doc/tutorial_bmad_tao.tex
@@ -79,7 +79,7 @@
 
 \title{An Introduction and Tutorial to Bmad and Tao}
 \author{}
-\date{David Sagan and Chris Mayes \\ July 18, 2024}
+\date{David Sagan and Chris Mayes \\ August 3, 2024}
 
 \begin{document}
 
@@ -2788,13 +2788,16 @@ changing the default universe.
 %----------------------------------------------------------
 \subsection{Overview}
 
-Control elements are elements that control the parameters of other elements. There are three types
-of control elements: \vn{groups}, \vn{overlays}, and \vn{girders}. \vn{Groups} and
+Control elements are elements that control the parameters of other elements. There are four types
+of control elements: \vn{groups}, \vn{overlays}, \vn{girders}, and \vn{rampers}. \vn{Groups} and
 \vn{overlays} are convenient to do such things as simulate control room "knobs". For example a power
 supply that powers a chain of magnets. \vn{Girder} elements (\sref{s:girder})
-are used for simulating lattice element support structures.
+are used for simulating lattice element support structures. And \vn{ramper} elements are used to
+vary lattice parameters over many turns which is useful for long term (that is multi-turn) tracking.
+\vn{Ramper} elements are not covered in this tutorial and the interested reader is referred to the \bmad
+manual for more details. 
 
-Note: \vn{Group}, \vn{overlay}, and \vn{girder} elements are known as ``\vn{minor} \vn{lords}'' since they
+Note: Control elements are known as ``\vn{minor} \vn{lords}'' since they
 only control a subset of an element's attributes. The other type of \vn{lord} elements, \vn{multipass} lords
 (\sref{s:multipass}) and \vn{superposition} lords (\sref{s:super}) are called ``\vn{major lords}''.
 

--- a/bmad/doc/elements.tex
+++ b/bmad/doc/elements.tex
@@ -4545,7 +4545,18 @@ not allowed to control \vn{rampers}. When a \vn{ramper} controls variables in ot
 elements it is not permitted to use wild card characters. That is, in the above example, ``\vn{*}''
 will not match to any controller elements.
 
-Do to the way bookkeeping is done for ramper elmeents, and unlike \vn{group} or \vn{overlay}
+If a slave name contains wild card characters, for a given lattice element that the slave name
+matches to, it is not required that the controlled attribute be a valid attribute of the element. In
+the case where the controlled attribute is not valid for a given lattice element, no attributes of
+the given lattice element are varied when and the ramper is varied. For example:
+\begin{example}
+  rz: ramper = \{*[k1]: ...
+\end{example}
+In this example the \vn{k1} attribute of all those elements that have a \vn{k1} attribute will be
+controlled but something like a \vn{sextupole} element which does not have a \vn{k1} attribute will
+not be controlled.
+
+Due to the way bookkeeping is done for ramper elmeents, and unlike \vn{group} or \vn{overlay}
 elements, it is not permitted for different \vn{ramper} elements to control the same parameter of a
 given slave element. Additionally, parameters that \vn{ramper} elements control must not be
 controlled by any \vn{overlay} (but a \vn{ramper} can control an \vn{overlay}).

--- a/bmad/parsing/bmad_parser_mod.f90
+++ b/bmad/parsing/bmad_parser_mod.f90
@@ -6621,6 +6621,15 @@ main_loop: do n_in = 1, n_ele_max
   !-----------------------------------------------------
   ! overlays, groups, and rampers
 
+  ! If a slave name does not match any name in lat and lord_lat then this is an error (to catch typos).
+  ! If a slave is defined in lord_lat but not present in lat then the slave is ignored.
+  ! If all slave elements are defined in lord_lat, but are not present in lat, then
+  ! this lord can be ignored.
+  ! Variation used by bmad_parser2: Check for missing slaves in check_lat instead of lord_lat.
+  ! Exception: If slave is overlay or group and is present later in the list of lords to be installed then
+  ! this is an error.
+  ! For rampers check that if there is a match then parameter matches a valid slave element.
+
   select case (lord%key)
 
   case (ramper$)
@@ -6681,16 +6690,7 @@ main_loop: do n_in = 1, n_ele_max
     call create_ramper (lat%ele(ix_lord), cs(1:nn), err)
 
   case (overlay$, group$)
- 
-    ! If a slave name does not match any name in lat and lord_lat then this is an error (to catch typos).
-    ! If a slave is defined in lord_lat but not present in lat then the slave is ignored.
-    ! If all slave elements are defined in lord_lat, but are not present in lat, then
-    ! this lord can be ignored.
-    ! Variation used by bmad_parser2: Check for missing slaves in check_lat instead of lord_lat.
-    ! Exception: If slave is overlay or group and is present later in the list of lords to be installed then
-    ! this is an error.
-
-    n_slave = 0
+     n_slave = 0
 
     if (allocated(m_eles)) deallocate (m_eles)
     allocate (m_eles(size(pele%control)))

--- a/bsim/long_term_tracking/examples/ramping_example/long_term_tracking.init
+++ b/bsim/long_term_tracking/examples/ramping_example/long_term_tracking.init
@@ -5,6 +5,7 @@
   ltt%ele_start = ''                   ! Where to start in the lattice
   ltt%ele_stop = ''                     ! Where to start in the lattice
 
+  ltt%beam_output_file = 'beam.h5'
   ltt%phase_space_output_file = ''
   ltt%averages_output_file = 'out'
   ltt%custom_output_file = 'custom.dat'

--- a/bsim/modules/lt_tracking_mod.f90
+++ b/bsim/modules/lt_tracking_mod.f90
@@ -47,7 +47,7 @@ type ltt_params_struct
   character(40) :: ele_extract = ''
   character(100) :: ele_write_at = ''
   character(200) :: lat_file = ''
-  character(200) :: beam_output_file = 'beam.h5'
+  character(200) :: beam_output_file = ''
   character(200) :: custom_output_file = ''
   character(200) :: map_file_prefix = ''
   character(200) :: map_ascii_output_file = ''

--- a/tao/version/tao_version_mod.f90
+++ b/tao/version/tao_version_mod.f90
@@ -6,5 +6,5 @@
 !-
 
 module tao_version_mod
-character(*), parameter :: tao_version_date = "2024/08/02 09:48:49"
+character(*), parameter :: tao_version_date = "2024/08/02 23:02:22"
 end module


### PR DESCRIPTION
Fix so ramper elements where no slave has the attribute to be controlled generates an error message.