### PR TITLE
tao_param_value_routine: handle long expressions

### DIFF
--- a/tao/code/tao_data_and_eval_mod.f90
+++ b/tao/code/tao_data_and_eval_mod.f90
@@ -5107,7 +5107,8 @@ character(*), optional :: dflt_dat_or_var_index
 
 character(1) delim
 character(16) s_str, source
-character(200) name, str2, word2
+character(200) name
+character(len(str)) :: str2, word2
 character(*), parameter :: r_name = 'tao_param_value_routine'
 
 logical use_good_user, err_flag, print_err, print_error, delim_found, valid_value, exterminate


### PR DESCRIPTION
You have this annoying user that insists on using long complex expressions. `tao_param_value_routine` was truncating sub-expressions because its intermediate strings weren't long enough. This patch fixes the problem. FYI error output from the buggy version looked like:
```
[ERROR | 2024-AUG-16 17:26:43] tao_evaluate_expression:
    UNMATCHED "("
    IN EXPRESSION: max(abs(ele::md[b_field]+ele::md[b1_gradient]*data::md.x
[ERROR | 2024-AUG-16 17:26:43] tao_evaluate_expression:
    ERROR IN EVALUATING EXPRESSION: max([max(abs(ele::mf##1[b_field]+ele::mf##1[b1_gradient]*data::mf.xm|model)),max(abs(ele::mf##1[b_field]+ele::mf##1[b1_gradient]*data::mf.xp|model)),max(abs(ele::md[b_field]+ele::md[b1_gradient]*data::md.xm|model)),max(abs(ele::md[b_field]+ele::md[b1_gradient]*data::md.xm|model))])
    CANNOT EVALUATE: [max(abs(ele::mf##1[b_field]+ele::mf##1[b1_gradient]*data::mf.xm|model)),max(abs(ele::mf##1[b_field]+ele::mf##1[b1_gradient]*data::mf.xp|model)),max(abs(ele::md[b_field]+ele::md[b1_gradient]*data::md.xm|model)),max(abs(ele::md[b_field]+ele::md[b1_gradient]*data::md.xm|model))]
[ERROR | 2024-AUG-16 17:26:43] tao_set_invalid:
    CANNOT EVALUATE EXPRESSION: max([max(abs(ele::mf##1[b_field]+ele::mf##1[b1_gradient]*data::mf.xm|model)),max(abs(ele::mf##1[b_field]+ele::mf##1[b1_gradient]*data::mf.xp|model)),max(abs(ele::md[b_field]+ele::md[b1_gradient]*data::md.xm|model)),max(abs(ele::md[b_field]+ele::md[b1_gradient]*data::md.xm|model))])
    FOR DATUM: field[1] with data_type: expression:max([max(abs(ele::mf##1[b_field]+ele::mf##1[b1_gradient]*data::mf.xm|model)),max(abs(ele::mf##1[b_field]+ele::mf##1[b1_gradient]*data::mf.xp|model)),max(abs(ele::md[b_field]+ele::md[b1_gradient]*data::md.xm|model)),max(abs(ele::md[b_field]+ele::md[b1_gradient]*data::md.xm|model))])
```

