### PR TITLE
CI: run the pytao test suite with every bmad commit

### DIFF
--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -1,0 +1,34 @@
+name: "conda setup"
+description: "Prepare the pytao conda environment"
+inputs:
+  python-version:
+    description: Python version
+    required: false
+    default: "3.9"
+  environment-file:
+    description: Conda environment file
+    required: true
+    default: "environment.yaml"
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Mambaforge
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        miniforge-variant: Mambaforge
+        activate-environment: pytao-dev
+        use-mamba: true
+        channels: conda-forge
+        environment-file: ${{ inputs.environment-file }}
+        python-version: ${{ inputs.python-version }}
+
+    - name: Show the installed packages
+      shell: bash -l {0}
+      run: |
+        conda list
+
+    - name: Ensure importability
+      shell: bash -l {0}
+      run: |
+        cd /
+        python -c "import pytao"

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -12,12 +12,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Setup Mambaforge
+    - name: Setup miniconda
       uses: conda-incubator/setup-miniconda@v3
       with:
-        miniforge-variant: Mambaforge
-        activate-environment: pytao-dev
+        miniforge-version: latest
         use-mamba: true
+        activate-environment: pytao-dev
         channels: conda-forge
         environment-file: ${{ inputs.environment-file }}
         python-version: ${{ inputs.python-version }}

--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -1,0 +1,35 @@
+name: setup-dependencies
+description: "Setup system and external dependencies to build bmad"
+inputs:
+  external-packages-version:
+    description: External packages version
+    required: false
+    default: "main"
+
+runs:
+  using: "composite"
+  steps:
+    # Install system dependencies
+    - name: Install System Dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install gfortran g++ cmake libtool-bin libreadline-dev libpango1.0-dev libssl-dev bc libopenmpi-dev openmpi-bin openmpi-common
+
+    - name: Checkout external packages
+      uses: actions/checkout@v4
+      with:
+        repository: "bmad-sim/bmad-external-packages"
+        ref: ${{ inputs.external-packages-version }}
+        path: "external_packages"
+        fetch-depth: 1
+
+    - name: Move External Packages
+      shell: bash
+      run: |
+        mv external_packages ~/
+        for dep in ~/external_packages/*; do 
+          if [ $dep != "README.md" ]; then
+            cp -r $dep $GITHUB_WORKSPACE/;
+          fi;
+        done

--- a/.github/scripts/install_bmad.sh
+++ b/.github/scripts/install_bmad.sh
@@ -9,6 +9,8 @@
 
 echo "**** Setup Preferences"
 
+echo "Number of processors: $(nproc)"
+
 cat <<EOF >> ./util/dist_prefs
 export DIST_F90_REQUEST="gfortran"
 export ACC_PLOT_PACKAGE="pgplot"
@@ -21,7 +23,7 @@ export ACC_ENABLE_SHARED="$SHARED"
 export ACC_ENABLE_SHARED_ONLY="$SHARED"
 export ACC_ENABLE_FPIC="Y"
 export ACC_ENABLE_PROFILING="N"
-export ACC_SET_GMAKE_JOBS="2"
+export ACC_SET_GMAKE_JOBS="$(nproc)"
 EOF
 
 echo "**** Invoking dist_source_me"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     #
     defaults:
-        run:
-          shell: bash
+      run:
+        shell: bash
 
     strategy:
       matrix:
@@ -49,37 +49,15 @@ jobs:
       # Check out the code from GitHub
       - uses: actions/checkout@v4
 
-      # Install system dependencies
-      - name: Install System Dependencies
-        run: |
-          sudo apt update
-          sudo apt-get install gfortran g++ cmake libtool-bin libreadline-dev libpango1.0-dev libssl-dev bc libopenmpi-dev openmpi-bin openmpi-common
+      - uses: ./.github/actions/setup-dependencies
+        with:
+          external-packages-version: ${{ env.EXTERNAL_PACKAGES_VERSION }}
 
-      # sudo apt install build-essential curl wget cmake gfortran automake \
-      # autoconf libtool m4 libgomp1 libreadline-dev libncurses-dev pkg-config \
-      # libcairo2-dev libpango1.0-dev libxt-dev libx11-dev -y
-
-      # In case we don't have it available, check it out
-      - name: Checkout External Packages
-        run: |
-          git clone --depth 1 --branch ${{ env.EXTERNAL_PACKAGES_VERSION }} https://github.com/bmad-sim/bmad-external-packages.git ~/external_packages
-
-      #
-      - name: Move External Packages
-        run: |
-          for dep in ~/external_packages/*; \
-          do if [ $dep != "README.md" ]; \
-            then cp -r $dep $GITHUB_WORKSPACE/; \
-            fi; \
-          done
-
-      #
-      - name: Build
+      - name: Build Bmad
         env:
           USE_MPI: ${{ matrix.openmp_mpi }}
           SHARED: ${{ matrix.shared }}
         run: .github/scripts/install_bmad.sh
 
-      #
       - name: Run Tests
         run: .github/scripts/run_tests.sh

--- a/.github/workflows/pytao.yml
+++ b/.github/workflows/pytao.yml
@@ -46,6 +46,8 @@ jobs:
       - name: Run Tests
         shell: bash -l {0}
         working-directory: ./pytao
+        env:
+          TAO_REUSE_SUBPROCESS: 1
         run: |
           export ACC_ROOT_DIR=$GITHUB_WORKSPACE
 

--- a/.github/workflows/pytao.yml
+++ b/.github/workflows/pytao.yml
@@ -1,0 +1,54 @@
+name: PyTao tests
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: ${{ matrix.os }} Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.12"]
+        shared: ["Y"]
+        openmp_mpi: ["N"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-dependencies
+        with:
+          external-packages-version: ${{ env.EXTERNAL_PACKAGES_VERSION }}
+
+      - name: Build Bmad
+        env:
+          USE_MPI: ${{ matrix.openmp_mpi }}
+          SHARED: ${{ matrix.shared }}
+        run: .github/scripts/install_bmad.sh
+
+      - uses: actions/checkout@v4
+        with:
+          repository: "bmad-sim/pytao"
+          ref: "master"
+          path: "pytao"
+
+      - uses: ./.github/actions/conda-setup
+        with:
+          python-version: ${{ matrix.python-version }}
+          environment-file: pytao/dev-environment.yml
+
+      - name: Run Tests
+        shell: bash -l {0}
+        working-directory: ./pytao
+        run: |
+          export ACC_ROOT_DIR=$GITHUB_WORKSPACE
+
+          echo -e '## Test results\n\n```' >> "$GITHUB_STEP_SUMMARY"
+          pytest -v --cov=pytao/ pytao/tests 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pytao.yml
+++ b/.github/workflows/pytao.yml
@@ -52,5 +52,5 @@ jobs:
           export ACC_ROOT_DIR=$GITHUB_WORKSPACE
 
           echo -e '## Test results\n\n```' >> "$GITHUB_STEP_SUMMARY"
-          pytest -v --cov=pytao/ pytao/tests 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
+          pytest -v --cov=pytao/ -k 'interface_commands or parse' pytao/tests 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Changes

* Added a pytao continuous integration test workflow
   * It builds and tests the latest bmad with the latest pytao master
   * It only runs Python 3.12 with shared libraries and MPI off
* Added pytao-focused `conda-setup` action 
* Moved dependency setup to its own composite action, so it could be shared with the pytao workflow
* Adjusted `install_bmad.sh` to use `nproc` instead of just hard-coding `2`. 
   * GitHub actions workers have 4 vCPUs - which resulted in a few minutes shaved off the bmad build in my limited testing.
* Adjust the test suite workflow to build on every commit
   * It's common for collaborators to make feature branches, so it would be nice if forks would run the test suite by default as well

Since it builds bmad and then runs the 600ish tests bundled with pytao, it ends up taking a rather long time (~35 minutes). 

### Future possibilities

* The pytao installation could be used to run additional integration tests. In my opinion:
   * Data files should continue to live in `bmad-doc`/`tao_examples` (or `regression_tests` depending on the purpose)
   * The pytest test suites that utilize those data files should live in the pytao repository
* This could potentially be changed at some point to reuse the build from the primary bmad build/test suite (i.e., the `ci.yml` job) down the line, but I don't have the time for it right now.