### PR TITLE
CI: regenerate Tao interface commands prior to running PyTao tests

### DIFF
--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -21,6 +21,7 @@ runs:
         channels: conda-forge
         environment-file: ${{ inputs.environment-file }}
         python-version: ${{ inputs.python-version }}
+        conda-remove-defaults: true
 
     - name: Show the installed packages
       shell: bash -l {0}

--- a/.github/workflows/pytao.yml
+++ b/.github/workflows/pytao.yml
@@ -43,6 +43,20 @@ jobs:
           python-version: ${{ matrix.python-version }}
           environment-file: pytao/dev-environment.yml
 
+      - name: Regenerate Tao interface commands
+        shell: bash -l {0}
+        working-directory: ./pytao
+        run: |
+          bash scripts/bump_minimum_version.sh
+
+      - name: Check Python source diff
+        shell: bash -l {0}
+        working-directory: ./pytao
+        run: |
+          echo -e '## Updated Python code\n\n```' >> "$GITHUB_STEP_SUMMARY"
+          git diff | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
       - name: Run Tests
         shell: bash -l {0}
         working-directory: ./pytao

--- a/.github/workflows/pytao.yml
+++ b/.github/workflows/pytao.yml
@@ -54,6 +54,13 @@ jobs:
         run: |
           bash scripts/bump_minimum_version.sh
 
+      - name: Reformat the generated source code
+        shell: bash -l {0}
+        working-directory: ./pytao
+        run: |
+          python -m pip install pre-commit
+          pre-commit run --all-files || echo "Pre-commit failed with error code $?"
+
       - name: Check Python source diff
         shell: bash -l {0}
         working-directory: ./pytao

--- a/.github/workflows/pytao.yml
+++ b/.github/workflows/pytao.yml
@@ -43,6 +43,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
           environment-file: pytao/dev-environment.yml
 
+      - name: Setup ACC_ROOT_DIR
+        shell: bash -l {0}
+        run: |
+          echo "ACC_ROOT_DIR=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+
       - name: Regenerate Tao interface commands
         shell: bash -l {0}
         working-directory: ./pytao
@@ -63,8 +68,6 @@ jobs:
         env:
           TAO_REUSE_SUBPROCESS: 1
         run: |
-          export ACC_ROOT_DIR=$GITHUB_WORKSPACE
-
           echo -e '## Test results\n\n```' >> "$GITHUB_STEP_SUMMARY"
           pytest -v --cov=pytao/ -k 'interface_commands or parse' pytao/tests 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
* Regenerate Tao interface commands prior to running PyTao tests
   * Ensures that the commands are up-to-date (e.g., new `tao.wall3d_radius`)
   * Ensures that all command examples are added to the test suite

This could have caught the issue in #1308 - assuming that an example was added to the command's documentation string.