### PR TITLE
Now OpenMP version of opti_de used when OMP is present.

### DIFF
--- a/tao/code/tao_de_optimizer.f90
+++ b/tao/code/tao_de_optimizer.f90
@@ -17,6 +17,7 @@ subroutine tao_de_optimizer (abort)
 use tao_interface, dummy => tao_de_optimizer
 use tao_top10_mod, only: tao_var_write
 use opti_de_mod
+use opti_de_openmp_mod
 
 implicit none
 
@@ -61,7 +62,11 @@ merit_start = tao_merit ()
 write (line, '(a, i0)') 'Differential evolution optimizer, population: ', population
 call out_io (s_blank$, r_name, line)
 
-merit = opti_de (var_vec, s%global%n_opti_cycles, population, merit_wrapper, var_step, status)
+if (s%com%omp_n_threads == 1) then
+  merit = opti_de (var_vec, s%global%n_opti_cycles, population, merit_wrapper, var_step, status)
+else
+  merit = opti_de_openmp (var_vec, s%global%n_opti_cycles, population, merit_wrapper, var_step, status)
+endif
 
 print *, 'tao_de_optimizer merit for rank ', merit, s%mpi%rank
 

--- a/tao/code/tao_init.f90
+++ b/tao/code/tao_init.f90
@@ -45,7 +45,7 @@ character(16) :: r_name = 'tao_init'
 character(16) init_name
 
 integer i, i0, j, i2, j2, n_universes, iu, ix, ib, ip, ios, ie
-integer iu_log, omp_n
+integer iu_log
 
 logical err_flag
 logical err, calc_ok, valid_value, this_calc_ok, using_default
@@ -76,8 +76,8 @@ endif
 
 ! OpenMP info
 
-!$ omp_n = omp_get_max_threads()
-!$ call out_io (s_important$, r_name, 'OpenMP active with number of threads: ' // int_str(omp_n))
+!$ s%com%omp_n_threads = omp_get_max_threads()
+!$ call out_io (s_important$, r_name, 'OpenMP active with number of threads: ' // int_str(s%com%omp_n_threads))
 
 ! Open the init file.
 ! If the init file name is *not* the default (that is, it has been set by

--- a/tao/code/tao_struct.f90
+++ b/tao/code/tao_struct.f90
@@ -755,6 +755,7 @@ type tao_common_struct
   integer :: lev_loop = 0                       ! in do loop nest level
   integer :: n_err_messages_printed = 0         ! Used by tao_set_invalid to limit number of messages.
   integer :: n_universes = n_uni_init$   
+  integer :: omp_n_threads = 1                  ! Number of OpenMP threads.
   logical :: cmd_file_paused = .false.
   logical :: use_cmd_here  = .false.            ! Used for commands recalled from the cmd history stack
   logical :: cmd_from_cmd_file = .false.        ! was command from a command file?


### PR DESCRIPTION
Now OpenMP version of opti_de used when OMP is present.