### PR TITLE
Tao: Expose the beam tracking active element index via C API

### DIFF
--- a/tao/code/tao_c_interface_mod.f90
+++ b/tao/code/tao_c_interface_mod.f90
@@ -290,4 +290,20 @@ tao_c_interface_com%n_int = 0
 
 end subroutine tao_c_out_io_buffer_reset
 
+!------------------------------------------------------------------------
+!------------------------------------------------------------------------
+!------------------------------------------------------------------------
+!+ 
+! Subroutine tao_c_get_beam_track_active_element() bind(c) result (ix_ele)
+!
+! Get the active element index being tracked through `tao_beam_track`.
+!-
+
+function tao_c_get_beam_track_element() bind(c) result (ix_ele)
+
+integer(c_int) :: ix_ele
+ix_ele = s%com%ix_beam_track_active_element
+
+end function tao_c_get_beam_track_element
+
 end module tao_c_interface_mod

--- a/tao/code/tao_lattice_calc_mod.f90
+++ b/tao/code/tao_lattice_calc_mod.f90
@@ -521,6 +521,9 @@ n_slice = max(1, int(1.01_rp*ele%value(l$) / ds_save))
 
 do
   n_loop = n_loop + 1
+
+  s%com%ix_beam_track_active_element = ie
+
   ! track to the element and save for phase space plot
 
   if (s%com%use_saved_beam_in_tracking) then

--- a/tao/code/tao_struct.f90
+++ b/tao/code/tao_struct.f90
@@ -755,6 +755,7 @@ type tao_common_struct
   integer :: lev_loop = 0                       ! in do loop nest level
   integer :: n_err_messages_printed = 0         ! Used by tao_set_invalid to limit number of messages.
   integer :: n_universes = n_uni_init$   
+  integer :: ix_beam_track_active_element = -1  ! Element being tracked through `tao_beam_track`.
   logical :: cmd_file_paused = .false.
   logical :: use_cmd_here  = .false.            ! Used for commands recalled from the cmd history stack
   logical :: cmd_from_cmd_file = .false.        ! was command from a command file?


### PR DESCRIPTION
## Changes

* Adds `s%com%ix_beam_track_active_element`, indicating the current element index being tracked through `tao_beam_track`
* Exposes this value with new C interface exported function `tao_c_get_beam_track_element`.

This pairs with a change in PyTao: https://github.com/bmad-sim/pytao/pull/125

## Why?

* Currently, through the C interface, we can only set `track_type = beam` as a normal command and then wait for the final output text to see what Tao did.
* With this PR, we can spawn a separate thread to poll the status of tracking and generate progress bars, giving the user a better indication as to what's going on

## Screenshots

* Using PyTao in Jupyter Lab:

https://github.com/user-attachments/assets/ed987e51-119b-4da0-96f6-b0c20135a451

* Using PyTao in the terminal:

https://github.com/user-attachments/assets/667e92bf-08b0-49f7-9abb-ad396ab9a3e2
