### PR TITLE
Now ele%spin_taylor_ref_orb_in is properly set in make_mat6_tracking.

### DIFF
--- a/bmad/low_level/make_mat6_tracking.f90
+++ b/bmad/low_level/make_mat6_tracking.f90
@@ -146,7 +146,7 @@ if (do_spin) then
     m(:,i) = ending%spin
   enddo
   q = w_mat_to_quat(m)
-
+  ele%spin_taylor_ref_orb_in = start_orb%vec
 else
   call track1(starting, ele, param, ending)
 endif


### PR DESCRIPTION
Now ele%spin_taylor_ref_orb_in is properly set in make_mat6_tracking.