### PR TITLE
CI: add workflow to build/test bmad with just conda

### DIFF
--- a/.github/bmad-build-env.yaml
+++ b/.github/bmad-build-env.yaml
@@ -1,0 +1,35 @@
+# conda env create -f environment.yml
+name: bmad-build
+channels:
+  - conda-forge
+dependencies:
+  - compilers
+  - cmake
+  - autoconf
+  - automake
+  - cairo
+  - fftw
+  - fgsl
+  - gnuconfig # [unix]
+  - gsl
+  - hdf5
+  - lapack95
+  - libblas * *openblas
+  - libcblas
+  - liblapack
+  - libtool
+  - m4
+  - make
+  - ncurses
+  - openblas
+  - openmpi
+  - pango
+  - pgplot
+  - pip
+  - pkg-config
+  - python
+  - readline
+  - xorg-libx11
+  - xorg-libxt
+  - xorg-xproto
+  - xraylib

--- a/.github/scripts/install_bmad.sh
+++ b/.github/scripts/install_bmad.sh
@@ -11,7 +11,7 @@ echo "**** Setup Preferences"
 
 echo "Number of processors: $(nproc)"
 
-cat <<EOF >> ./util/dist_prefs
+cat <<EOF >>./util/dist_prefs
 export DIST_F90_REQUEST="gfortran"
 export ACC_PLOT_PACKAGE="pgplot"
 export ACC_PLOT_DISPLAY_TYPE="X"
@@ -25,6 +25,23 @@ export ACC_ENABLE_FPIC="Y"
 export ACC_ENABLE_PROFILING="N"
 export ACC_SET_GMAKE_JOBS="$(nproc)"
 EOF
+
+if [ "$USE_CONDA" == "1" ]; then
+  [ -z "$CONDA_PREFIX" ] && {
+    echo "CONDA_PREFIX unset?"
+    exit 1
+  }
+
+  echo "* Using conda to build: $CONDA_PREFIX"
+
+  cat <<EOF >>./util/dist_prefs
+export ACC_CONDA_BUILD="Y"
+export ACC_CONDA_BUILD_TESTS="Y"
+export ACC_CONDA_PATH="$CONDA_PREFIX"
+export ACC_USE_MACPORTS="N"
+EOF
+
+fi
 
 echo "**** Invoking dist_source_me"
 source ./util/dist_source_me

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -1,0 +1,68 @@
+name: Bmad-ecosystem - Conda build & test
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-conda:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubuntu-single-core
+            os: ubuntu-latest
+            shared: Y
+            openmp_mpi: N
+          - name: macos-single-core
+            os: macos-latest
+            shared: Y
+            openmp_mpi: N
+          - name: ubuntu-openmp
+            os: ubuntu-latest
+            shared: Y
+            openmp_mpi: Y
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Include Linux-only requirements
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        shell: bash -eo pipefail -l {0}
+        run: |
+          echo '  - libacl' >> .github/bmad-build-env.yaml
+          echo '  - libgomp' >> .github/bmad-build-env.yaml
+
+      - name: Setup miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: latest
+          use-mamba: true
+          activate-environment: bmad-build
+          channels: conda-forge
+          environment-file: .github/bmad-build-env.yaml
+          python-version: 3.12
+          conda-remove-defaults: true
+
+      - name: Include OpenMPI variants (if using MPI)
+        if: ${{ matrix.openmp_mpi == 'Y' }}
+        shell: bash -eo pipefail -l {0}
+        run: conda install -y 'hdf5=*=mpi_openmpi*'
+
+      - name: Build Bmad with Conda
+        env:
+          USE_MPI: ${{ matrix.openmp_mpi }}
+          SHARED: ${{ matrix.shared }}
+          USE_CONDA: 1
+        shell: bash -eo pipefail -l {0}
+        run: .github/scripts/install_bmad.sh
+
+      - name: Run Tests
+        shell: bash -eo pipefail -l {0}
+        run: .github/scripts/run_tests.sh 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"

--- a/bmad/CMakeLists.txt
+++ b/bmad/CMakeLists.txt
@@ -12,6 +12,7 @@ SET (PLOT_LINK_LIBS $ENV{PLOT_LINK_LIBS})
 
 IF ($ENV{ACC_CONDA_BUILD})
   SET (INC_DIRS
+    $ENV{ACC_CONDA_PATH}/include
     $ENV{ACC_CONDA_PATH}/include/xraylib/
     $ENV{ACC_CONDA_PATH}/include/fgsl/
   )

--- a/bsim/CMakeLists.txt
+++ b/bsim/CMakeLists.txt
@@ -2,8 +2,15 @@ set (LIBNAME bsim)
 cmake_minimum_required(VERSION $ENV{ACC_CMAKE_VERSION})
 project(ACC)
 
-set(INC_DIRS 
-)
+IF ($ENV{ACC_CONDA_BUILD})
+  SET (INC_DIRS
+    $ENV{ACC_CONDA_PATH}/include
+    $ENV{ACC_CONDA_PATH}/include/xraylib/
+  )
+ELSE ()
+  SET (INC_DIRS
+  )
+ENDIF ()
 
 set (SRC_DIRS
   code

--- a/regression_tests/CMakeLists.txt
+++ b/regression_tests/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required(VERSION $ENV{ACC_CMAKE_VERSION})
 project(ACC)
 
+IF ($ENV{ACC_CONDA_BUILD})
+  SET (INC_DIRS
+    $ENV{ACC_CONDA_PATH}/include
+    $ENV{ACC_CONDA_PATH}/include/xraylib/
+  )
+ENDIF ()
+
 set (EXE_SPECS 
   cmake_files/cmake.abs_time_test
   cmake_files/cmake.analysis_test

--- a/sim_utils/CMakeLists.txt
+++ b/sim_utils/CMakeLists.txt
@@ -11,6 +11,7 @@ SET (PLOT_LINK_LIBS $ENV{PLOT_LINK_LIBS})
 # one level deeper in the include folder
 IF ($ENV{ACC_CONDA_BUILD})
   SET (INC_DIRS
+    $ENV{ACC_CONDA_PATH}/include/
     $ENV{ACC_CONDA_PATH}/include/fgsl/
   )
 ELSE ()

--- a/util/Distribution_User_Utility_Wrapper
+++ b/util/Distribution_User_Utility_Wrapper
@@ -17,6 +17,12 @@ case "${ACC_CONDA_BUILD}" in
     ;;
 esac
 
+case "${ACC_CONDA_BUILD_TESTS}" in
+    "Y" | "y" | "1" )
+    CONDA_BUILD_TESTS=1
+    ;;
+esac
+
 if ( [[ "${CONDA_BUILD}" ]] ) ; then
     # For conda build most of the dependencies are pulled from conda-forge
     # We also remove code_examples and regression tests from the build list
@@ -24,6 +30,7 @@ if ( [[ "${CONDA_BUILD}" ]] ) ; then
     # List of Project Directories - Order here matters!
     DIRLIST=( forest sim_utils bmad tao cpp_bmad_interface bsim util_programs lux )
     [ "${ACC_PLOT_PACKAGE}" == "plplot" ] && DIRLIST=( plplot ${DIRLIST[*]} )
+    [ "${CONDA_BUILD_TESTS}" ] && DIRLIST=( ${DIRLIST[*]} regression_tests )
 else
     # List of Project Directories - Order here matters!
     DIRLIST=()

--- a/util/acc_build_common
+++ b/util/acc_build_common
@@ -158,13 +158,13 @@ func_set_openmp_flags () {
           # Fix setting OpenMP configure flag 12-Sep-2022
           export BUILD_OPENMP=1
 
-          if ( [[ "${CONDA_BUILD}" ]] ) ; then
-                export CFLAGS="${CFLAGS} -L${ACC_CONDA_PATH}/lib -I${ACC_CONDA_PATH}/include"
-                export FCFLAGS="${FFLAGS} -L${ACC_CONDA_PATH}/lib -I${ACC_CONDA_PATH}/include"
-                export LDFLAGS="-L${ACC_CONDA_PATH}/lib -Wl,-rpath,${ACC_CONDA_PATH}/lib ${LDFLAGS}"
+          if [[ "${CONDA_BUILD}" ]]; then
+            export CFLAGS="${CFLAGS} -L${ACC_CONDA_PATH}/lib -I${ACC_CONDA_PATH}/include"
+            export FCFLAGS="${FFLAGS} -L${ACC_CONDA_PATH}/lib -I${ACC_CONDA_PATH}/include"
+            export LDFLAGS="-L${ACC_CONDA_PATH}/lib -Wl,-rpath,${ACC_CONDA_PATH}/lib ${LDFLAGS}"
           fi
           export CFLAGS="-fopenmp ${CFLAGS}"
-          if ( [ "${FC}" == "gfortran" ] ) ; then
+          if [ "${FC}" == "gfortran" ] ; then
             export FCFLAGS="-fopenmp ${FCFLAGS}"
             export LDFLAGS="-lgomp ${LDFLAGS}"
           elif [ "${IFORT_MAJOR_VERSION}" ] ; then
@@ -379,7 +379,7 @@ func_check_fortran_version () {
     
 func_install_utilities () {
     # We don't need to install utilities for CONDA builds
-    if ( [[ "${CONDA_BUILD}" ]] ) ; then
+    if [[ "${CONDA_BUILD}" ]]; then
            return
     fi
 
@@ -618,7 +618,7 @@ func_set_fortran_flags () {
     fi
 
     # For ifort, move STACK memory to the HEAP, see RT#45710
-    if [ "${FC}" != "gfortran" ] ; then
+    if [ "${FC}" != "gfortran" ]; then
       export BASE_OPTS="${BASE_OPTS} -heap-arrays 32"
     fi
 

--- a/util/dist_source_me
+++ b/util/dist_source_me
@@ -42,7 +42,7 @@ func_set_os_env () {
 
     export ACC_COMPILER_TOOLSET=default
 
-    if ( [[ "${CONDA_BUILD}" ]] ) ; then
+    if [[ "${CONDA_BUILD}" ]]; then
         # No need to set os env for Conda Build.
         return;
     fi
@@ -339,7 +339,7 @@ func_add_bmad_path () {
 
     export PATH=${USER_PATH}
 
-    if ( [[ "${CONDA_BUILD}" ]] ) ; then
+    if [[ "${CONDA_BUILD}" ]]; then
         export LD_LIBRARY_PATH=${ACC_CONDA_PATH}/lib:${LD_LIBRARY_PATH}
     fi
 
@@ -445,6 +445,13 @@ case "${ACC_CONDA_BUILD}" in
 esac
 
 
+case "${ACC_CONDA_BUILD_TESTS}" in
+    "Y" | "y" | "1" )
+        CONDA_BUILD_TESTS=1
+        ;;
+esac
+
+
 #-----------------------------------------------------------------
 # Main Script
 #
@@ -471,7 +478,7 @@ CWD_DIR_CHECK=$(func_is_dir_toplevel ${CWD})
 DIST_BASE_DIR_CHECK=$(func_is_dir_toplevel ${DIST_BASE_DIR})
 
 
-if ( [[ "${CONDA_BUILD}" ]] ) ; then
+if [[ "${CONDA_BUILD}" ]]; then
     DIST_SETUP_LOG=/dev/stdout
     DIST_SETUP_QUIET="Y"
 fi
@@ -490,7 +497,7 @@ if ( [ "${CWD_DIR_CHECK}" == "Y" ] && [[ ! ${CWD} -ef ${DIST_BASE_DIR} ]]) ; the
     func_set_os_env
     func_set_bmad_env
     func_add_bmad_path
-    if ( [[ ! "${CONDA_BUILD}" ]] ) ; then
+    if [[ ! "${CONDA_BUILD}" ]] ; then
     func_check_fortran_version
     func_macos_gcc
     fi
@@ -502,7 +509,7 @@ elif ( [ "${DIST_BASE_DIR_CHECK}" == "Y" ] ) ; then
     func_set_os_env
     func_set_bmad_env
     func_add_bmad_path
-    if ( [[ ! "${CONDA_BUILD}" ]] ) ; then
+    if [[ ! "${CONDA_BUILD}" ]]; then
         func_check_fortran_version
         func_macos_gcc
     fi
@@ -534,6 +541,6 @@ echo -e "     https://wiki.classe.cornell.edu/ACC/ACL/OffsiteDoc\n" \
 #-----------------------------------------------------------------
 # Display Logfile, unless requested not to.
 #-----------------------------------------------------------------
-if ( [[ ! "${CONDA_BUILD}" ]] ) ; then
+if [[ ! "${CONDA_BUILD}" ]]; then
     [ "${DIST_SETUP_QUIET}" != "Y" ] && cat ${DIST_SETUP_LOG}
 fi


### PR DESCRIPTION
## Description

This PR adds a workflow that builds bmad-ecosystem with conda dependencies only, and then runs the regression test suite.

This offers a significant speed-up over the current build procedure, as we can skip building all of the dependencies from source (hdf5, lapack, etc.).

## Speed-up

How much faster is it? It takes about half the time to build and test.

Current build and test workflow - around 16 minutes:
<img width="326" alt="image" src="https://github.com/user-attachments/assets/5762edf6-e6b6-4129-afc8-6a285d1abd05" />

New build and test workflow - around 8 minutes:
<img width="312" alt="image" src="https://github.com/user-attachments/assets/4485cca7-ae08-4232-921d-c933a094ace8" />

## Changes

* Created a new GitHub Actions workflow that builds bmad (including the regression tests) and runs them using `pytest`
   * This tests on Linux (no MPI, OpenMPI versions) and MacOS ARM64 (no MPI).
   * Modified `.github/scripts/install_bmad.sh` to support building with conda and setting appropriate environment variables
   * Added base conda environment yaml file, shared among the MacOS/Linux build step
* Adds `CONDA_BUILD_TESTS` flag for building regression test binaries with conda (which was not previously configurable)
* Removed some unnecessary syntax in build scripts that I noticed, while debugging local build issues (`if ( [[ ]] ); then` is equivalent to `if [[ ]]; then` in bash, the former just creates an unnecessary subshell.)

## Uh oh

But wait... there's a couple failing tests. They are running correctly, but the results are slightly different. Is this something we should be concerned about?

Ubuntu test failure:

* `photon_test`
  ```
  Regression test local failure: reflect_table-field
     Data from "output.now":     [0.7962371623, 1.5924743247]
     Data from "output.correct": [0.7962371393, 1.5924742786]
     Diff: 4.610000003957282e-08 Diff/Val: 2.8948661835112525e-08
  ```

MacOS test failures:

* `mat6_calc_method_test`

  ```
   Regression test local failure: CRAB_CAVITY1:Tracking:MatrixRow6
     Data from "output.now":     [0.00090788304222579, 9.0246396466931e-05, 0.0, -2.546140381865e-09, 7.6200398421711e-06, 0.99999957183113]
     Data from "output.correct": [0.00090788305575663, 9.0246416763196e-05, 0.0, -2.5393315922217e-09, 7.6200669472254e-06, 0.99999957183113]
     Diff: 2.710505430027915e-11 Diff/Val: 3.5570688151788856e-06
  ```

* `spin_general_test`
  ```
  Regression test local failure: Integral g^3 * b_hat * dn/ddelta
     Data from "output.now":     [2.61104609e-17]
     Data from "output.correct": [2.71191375e-18]
     Diff: 2.339854715e-17 Diff/Val: 1.6236377074503123
  ```
  
## What next?

After addressing the failures above, of course.

If you end up liking this approach, we might choose one or more of the following:

* Keep this in addition to the other workflows
* Use this workflow to replace the existing build/test workflow
* Use this workflow to replace the build procedure in the pytest workflow