### PR TITLE
tao_evaluate_expression: check associated(dflt_ele)

### DIFF
--- a/tao/code/tao_evaluate_expression.f90
+++ b/tao/code/tao_evaluate_expression.f90
@@ -96,7 +96,9 @@ default_source = ''
 if (present(dflt_source)) default_source = dflt_source
 
 phrase = expression
-if (present(dflt_ele)) call tao_expression_hash_substitute(phrase, ele_full_name(dflt_ele, '!#'))
+if (present(dflt_ele)) then
+   if (associated(dflt_ele)) call tao_expression_hash_substitute(phrase, ele_full_name(dflt_ele, '!#'))
+end if
 
 if (len(phrase) > 11) then
   if (phrase(1:11) == 'expression:') phrase = phrase(12:)


### PR DESCRIPTION
dflt_ele can be present but not associated. Need to check associated before using. See #1539 