### PR TITLE
REF/FIX: retain n_threads after 'reinit tao -clear'

### DIFF
--- a/tao/code/tao_parse_command_args.f90
+++ b/tao/code/tao_parse_command_args.f90
@@ -25,7 +25,7 @@ character(200) :: cmd_words(12)
 character(80) arg0, arg1, base, switch
 character(*), parameter :: r_name = 'tao_parse_command_args'
 
-integer n_arg, i_arg, ix
+integer n_arg, i_arg, ix, old_n_threads
 logical error, negate
 
 ! Init global and common structs.
@@ -114,8 +114,9 @@ do
   case ('-clear')
     s%init = tao_init_struct()
     s%com = tao_common0
+    old_n_threads = s%global%n_threads
     s%global = tao_global_struct()
-    call tao_set_openmp_n_threads(s%global%n_threads)
+    s%global%n_threads = old_n_threads
 
   case ('-command')
     call get_next_arg (arg0, s%init%command_arg, i_arg, n_arg, .true.)

--- a/tao/doc/command-list.tex
+++ b/tao/doc/command-list.tex
@@ -1357,6 +1357,16 @@ Example:
   set global rf_on = T          ! Turn on the RF cavities.
 \end{example}
 
+For users who have OpenMP support enabled for parallel calculations, the global
+parameter \vn{n_threads} may be set at runtime to configure the
+\vn{OMP_NUM_THREADS} on the fly.
+
+Example:
+\begin{example}
+  set global n_threads = 1  ! Use only a single thread
+  set global n_threads = 4  ! Use four threads
+\end{example}
+
 %% set graph --------------------------------------------------------------
 
 \subsection{set graph}

--- a/tao/doc/introduction.tex
+++ b/tao/doc/introduction.tex
@@ -45,6 +45,14 @@ To set the number of threads when running a program compiled with \vn{OpenMP}, s
   export OMP_NUM_THREADS=8
 \end{example}
 
+This may also be set during Tao runtime as the global parameter \vn{n_threads}. For example:
+\begin{example}
+  set global n_threads = 1  ! Use only a single thread
+  set global n_threads = 4  ! Use four threads
+\end{example}
+
+See \sref{s:set.global} for more information.
+
 To the local \bmad Guru: Compiling and linking of \tao with \vn{OpenMP} is documented on the \bmad
 web site. By default, \vn{OpenMP} is not enabled. Essentially, OpenMP is enabled by modifying
 the \vn{dist_prefs} file before compiling and linking.


### PR DESCRIPTION
This PR makes `s%global%n_threads` persist even after a `reinit tao -clear`.

`s%global%n_threads` could be considered a bit of a special case; resetting it may end up surprising the user and result in unexpectedly slow simulations.