### PR TITLE
MAINT: potential fix for hdf5 fortran HL on arm64+openmpi+conda

### DIFF
--- a/util/Master.cmake
+++ b/util/Master.cmake
@@ -502,8 +502,9 @@ foreach(h5dir ${HDF5_Fortran_INCLUDE_DIRS})
   endif()
 endforeach()
 if (HDF5_FOUND)
+  list(FILTER HDF5_Fortran_HL_LIBRARIES EXCLUDE REGEX "-NOTFOUND$")
+  list(FILTER HDF5_Fortran_LIBRARIES EXCLUDE REGEX "-NOTFOUND$")
   set(SHARED_LINK_LIBS ${HDF5_Fortran_HL_LIBRARIES} ${HDF5_Fortran_LIBRARIES} ${SHARED_LINK_LIBS})
-  list(FILTER SHARED_LINK_LIBS EXCLUDE REGEX "-NOTFOUND$")
 endif()
 
 #------------------------------------------------------

--- a/util/Master.cmake
+++ b/util/Master.cmake
@@ -503,6 +503,7 @@ foreach(h5dir ${HDF5_Fortran_INCLUDE_DIRS})
 endforeach()
 if (HDF5_FOUND)
   set(SHARED_LINK_LIBS ${HDF5_Fortran_HL_LIBRARIES} ${HDF5_Fortran_LIBRARIES} ${SHARED_LINK_LIBS})
+  list(FILTER SHARED_LINK_LIBS EXCLUDE REGEX "-NOTFOUND$")
 endif()
 
 #------------------------------------------------------


### PR DESCRIPTION
I'm no CMake expert, but this patch appears to work (ref #1555) on conda-forge: https://github.com/conda-forge/bmad-feedstock/pull/564/checks