### PR TITLE
Included `ct_map%field_scale` in `symp_lie_bmad` orbit tracking

### DIFF
--- a/bmad/low_level/symp_lie_bmad.f90
+++ b/bmad/low_level/symp_lie_bmad.f90
@@ -742,7 +742,7 @@ real(rp) factor, coef
 integer j
 logical do_mat6
 
-factor = charge_of(start_orb%species) * c_light * field_ele%value(polarity$) / ele%value(p0c$)
+factor = charge_of(start_orb%species) * c_light * field_ele%value(polarity$) * ct_map%field_scale / ele%value(p0c$)
 
 do j = 1, num_wig_terms
   wt => wig_term(j)


### PR DESCRIPTION
`symp_lie_bmad` orbit tracking does not re-use the `em_field_calc` method which is used in the spin tracking component, and misses the `ct_map%field_scale` normalization factor. 