### PR TITLE
Fix interface argument names, some `optional` annotations

### DIFF
--- a/bmad/code/kill_taylor.f90
+++ b/bmad/code/kill_taylor.f90
@@ -5,10 +5,10 @@
 ! It is OK if the taylor has already been deallocated.
 !
 ! Input:
-!   bmad_taylor(:)   -- Taylor_struct, optional: Taylor to be deallocated. 
+!   bmad_taylor(:)   -- Taylor_struct: Taylor to be deallocated. 
 !
 ! Output:
-!   bmad_taylor(:)   -- Taylor_struct, optional: deallocated Taylor structure.
+!   bmad_taylor(:)   -- Taylor_struct: deallocated Taylor structure.
 !-
 
 subroutine kill_taylor (bmad_taylor)

--- a/bmad/code/momentum_compaction.f90
+++ b/bmad/code/momentum_compaction.f90
@@ -8,7 +8,7 @@
 !   gamma_transition = 1 / sqrt(mom_comp)
 !
 ! Input:
-!   branch      -- branch_struct, optional: Lattice branch to calculate on.
+!   branch      -- branch_struct: Lattice branch to calculate on.
 !
 ! Output:
 !   mom_comp    -- real(rp): Momentum compaction.

--- a/bmad/custom/em_field_custom.f90
+++ b/bmad/custom/em_field_custom.f90
@@ -41,7 +41,7 @@
 !
 ! Output:
 !   field    -- Em_field_struct: Structure hoding the field values.
-!   err_flag -- Logical, optional: Set true if there is an error. False otherwise.
+!   err_flag -- Logical: Set true if there is an error. False otherwise.
 !-
 
 recursive subroutine em_field_custom (ele, param, s_rel, orbit, local_ref_frame, field, calc_dfield, err_flag, &

--- a/bmad/modules/mode3_mod.f90
+++ b/bmad/modules/mode3_mod.f90
@@ -442,7 +442,7 @@ end subroutine action_to_xyz
 ! Output:
 !   eval(6)      -- complex(rp):  complex eigenvalues.
 !   evec(6,6)    -- complex(rp):  complex eigenvectors arranged down columns.
-!   err_flag     -- logical, optional: set to true if an error has occured.
+!   err_flag     -- logical: set to true if an error has occured.
 !   tunes(3)     -- real(rp):  Mode tunes, in radians.
 !-
 

--- a/bmad/output/write_lattice_in_scibmad.f90
+++ b/bmad/output/write_lattice_in_scibmad.f90
@@ -7,8 +7,8 @@
 !   lat           -- lat_struct: Lattice
 !
 ! Output:
-!   scibmad_file  -- character(*), optional: SciBmad lattice file name.
-!   err_flag      -- logical, optional: Error flag
+!   scibmad_file  -- character(*): SciBmad lattice file name.
+!   err_flag      -- logical: Error flag
 !-
 
 subroutine write_lattice_in_scibmad(scibmad_file, lat, err_flag)

--- a/sim_utils/interfaces/sim_utils_interface.f90
+++ b/sim_utils/interfaces/sim_utils_interface.f90
@@ -207,11 +207,12 @@ subroutine faddeeva_function(z, w, dw)
   real(rp) z(2), w(2), dw(2,2)
 end subroutine
 
-subroutine fff_sub(line, error)
-  implicit none
-  character(*) line
-  logical error
-end subroutine
+! no longer exists
+! subroutine fff_sub(line, error)
+!   implicit none
+!   character(*) line
+!   logical error
+! end subroutine
 
 subroutine fft_1d (arr, isign)
   import
@@ -266,12 +267,13 @@ subroutine get_file_number (file_name, cnum_in, num_out, err_flag)
   logical err_flag
 end subroutine
 
-subroutine get_next_number (filein, cnum, digits)
-  implicit none
-  character(*) filein
-  character(*) cnum
-  integer digits
-end subroutine
+! no longer exists
+! subroutine get_next_number (filein, cnum, digits)
+!   implicit none
+!   character(*) filein
+!   character(*) cnum
+!   integer digits
+! end subroutine
 
 subroutine get_file_time_stamp (file, time_stamp)
   implicit none
@@ -328,12 +330,13 @@ function inverse (funct, y, x1, x2, tol) result (x)
   end interface
 end function
  
-function inverse_prob (val) result (prob)
-  import
-  implicit none
-  real(rp) prob 
-  real(rp) val
-end function
+! no longer exists
+! function inverse_prob (val) result (prob)
+!   import
+!   implicit none
+!   real(rp) prob 
+!   real(rp) val
+! end function
 
 function is_alphabetic (string, valid_chars) result (is_alpha)
   implicit none
@@ -912,10 +915,11 @@ function substr(var_str, n1, n2) result (sub_str)
   character(n2-n1+1) sub_str
 end function
 
-subroutine test_tune_tracker_lock (tracker_locked)
-  implicit none
-  logical tracker_locked(2)
-end subroutine
+! no longer exists
+! subroutine test_tune_tracker_lock (tracker_locked)
+!   implicit none
+!   logical tracker_locked(2)
+! end subroutine
 
 function to_str(num, max_signif) result (string)
   import

--- a/sim_utils/math/random_mod.f90
+++ b/sim_utils/math/random_mod.f90
@@ -426,7 +426,7 @@ end subroutine ran_gauss_converter
 ! Note: Use pointer_to_ran_state() to access the ran state directly.
 !
 ! Input:
-!   seed        -- integer, optional: Seed number. If seed = 0 then a 
+!   seed        -- integer: Seed number. If seed = 0 then a 
 !                   seed will be choosen based upon the system clock.
 !   mpi_offset  -- integer, optional: Offset added to seed. Default is zero.
 !                   Used with MPI processes ensure different threads use different random numbers.

--- a/tao/code/tao_interface.f90
+++ b/tao/code/tao_interface.f90
@@ -452,8 +452,9 @@ function tao_graph_name(graph, use_region) result (graph_name)
   logical, optional :: use_region
 end function
 
-subroutine tao_has_been_created ()
-end subroutine
+! TODO this no longer exists
+! subroutine tao_has_been_created ()
+! end subroutine
  
 subroutine tao_help (what1, what2, lines, n_lines)
   implicit none
@@ -488,10 +489,11 @@ subroutine tao_init_plotting (plot_file)
   character(*) plot_file
 end subroutine
 
-subroutine tao_init_single_mode (single_mode_file)
-  implicit none
-  character(*) single_mode_file
-end subroutine
+! TODO this no longer exists
+! subroutine tao_init_single_mode (single_mode_file)
+!   implicit none
+!   character(*) single_mode_file
+! end subroutine
 
 function tao_is_valid_name (name, why_invalid) result (is_valid)
   implicit none


### PR DESCRIPTION
Changes:
* Fixes some bmad routine interface argument names to match the underlying implementation source
* Fixes some documentation argument `optional` annotations which were inaccurately marked as `optional`
* Removes a number of missing routines from the interface definitions - I assume these were deleted from the codebase at some point in the past

For context, this information is parsed and used to generate the new C++ and Python bindings.