### PR TITLE
`em_field_calc`: move up `rb_field` to avoid trampoline of internal procedure

### DIFF
--- a/bmad/code/em_field_calc.f90
+++ b/bmad/code/em_field_calc.f90
@@ -58,7 +58,8 @@ type (ele_pointer_struct), allocatable :: used_list(:)
 type (ele_struct), pointer :: lord, ele2
 type (ele_struct), optional :: original_ele
 type (lat_param_struct) param
-type (coord_struct) :: orbit, local_orb, lab_orb, lord_orb, this_orb
+type (coord_struct) :: orbit, lab_orb, lord_orb, this_orb
+type (coord_struct), target :: local_orb
 type (em_field_struct) :: field, field1, field2, lord_field, l1_field, mode_field
 type (cartesian_map_struct), pointer :: ct_map
 type (cartesian_map_term1_struct), pointer :: ct_term
@@ -1421,6 +1422,13 @@ case(fieldmap$)
 
         if (logic_option(.false., calc_potential)) then
           if (r /= 0) then
+            rb_ele => ele
+            rb_orb => local_orb
+            rb_grid => g_field_ptr
+            rb_expt = expt
+            rb_print_err = logic_option(.true., print_err)
+            rb_z = z
+
             abs_tol = abs(1e-10_rp * r * orbit%p0c * (1 + orbit%vec(6)) / (c_light * charge_of(ele%ref_species)))
             inte = super_qromb(rb_field, 0.0_rp, r, 1e-12_rp, abs_tol, 2, err) / r
             field%A(1:2) = field%A(1:2) + inte * [-y, x] / r
@@ -1535,23 +1543,6 @@ if (.not. local_ref_frame) call convert_field_ele_to_lab (ele, s_body, .true., f
 !----------------------------------------------------------------------------
 contains
 
-! Function for vector potential calc.
-
-function rb_field(x)
-
-real(rp), intent(in) :: x(:)
-real(rp) :: rb_field(size(x))
-integer i
-
-!
-
-do i = 1, size(x)
-  call grid_field_interpolate(ele, local_orb, g_field_ptr, g_pt, err, x(i), z, &
-              allow_s_out_of_bounds = .true., print_err = print_err)
-  rb_field(i) = x(i) * expt_ptr * g_pt%b(3)
-enddo
-
-end function rb_field
 
 !----------------------------------------------------------------------------
 !----------------------------------------------------------------------------

--- a/bmad/modules/em_field_mod.f90
+++ b/bmad/modules/em_field_mod.f90
@@ -11,7 +11,36 @@ use taylor_mod
 
 implicit none
 
+type(ele_struct), pointer :: rb_ele => null()
+type(coord_struct), pointer :: rb_orb => null()
+type(grid_field_struct), pointer :: rb_grid => null()
+complex(rp) :: rb_expt
+logical :: rb_print_err
+real(rp) :: rb_z
+!$OMP THREADPRIVATE(rb_ele, rb_orb, rb_grid, rb_expt, rb_print_err, rb_z)
+
 contains
+
+!-----------------------------------------------------------------
+! Function for vector potential calc used by em_field_calc.
+
+function rb_field(x)
+
+real(rp), intent(in) :: x(:)
+real(rp) :: rb_field(size(x))
+type (grid_field_pt1_struct) g_pt
+logical err
+integer i
+
+!
+
+do i = 1, size(x)
+  call grid_field_interpolate(rb_ele, rb_orb, rb_grid, g_pt, err, x(i), rb_z, &
+              allow_s_out_of_bounds = .true., print_err = rb_print_err)
+  rb_field(i) = x(i) * rb_expt * g_pt%b(3)
+enddo
+
+end function rb_field
 
 !-----------------------------------------------------------------
 !-----------------------------------------------------------------


### PR DESCRIPTION
(Related to #1889 but does not close it)

In short: a massive performance penalty on MacOS with RK tracking can be avoided by moving around where `rb_field` is defined.

## Changes

This PR fixes a performance issue with the calculation of the vector potential in the electromagnetic field calculation routine, moving the currently nested `rb_field` function out of the local scope of `em_field_calc` and into the module scope in `em_field_mod`.

Some notes:
* The cause of this slowdown is entirely due to how passing **internal procedures** as parameters to another procedure relies on creating a "trampoline."  Based on what I've read, the largest performance penalty then only applies to MacOS and more secure Linux configurations that don't allow an executable stack (see below).
* I'm not an expert with OpenMP (or any of this, to be fair). I know that RK tracking uses OpenMP to parallelize the calculations, so the promoted `rb_*` variables used by `rb_field` were marked thread-private with OMP. This could use some validation.

## Performance profiling notes

This is on MacOS, with a non-OpenMP build.

**Before**
Prior to this PR, loading a very large lattice with RK tracking:

<img width="1353" height="804" alt="image" src="https://github.com/user-attachments/assets/f58664bd-6d5c-4647-af4d-ceb50cc72225" />

**After**
After this PR
<img width="1326" height="775" alt="image" src="https://github.com/user-attachments/assets/f6a57d02-e5f7-4445-832a-b132eb68ee4d" />

Tracking again happens after `bmad_parser2`, meaning the performance hit happens twice just in loading, leading to almost a penalty of 50% of the loading time. Our lattice parsing goes from 102 seconds down to 50 seconds.

### gcc background / OS-specific

Per `gcc` docs:


> `-ftrampoline-impl=[stack|heap]`
> 
>    By default, trampolines are generated on stack. However, certain platforms (such as the Apple M1) do not permit an executable stack. Compiling with -ftrampoline-impl=heap generate calls to __gcc_nested_func_ptr_created and __gcc_nested_func_ptr_deleted in order to allocate and deallocate trampoline space on the executable heap. These functions are implemented in libgcc, and will only be provided on specific targets: x86_64 Darwin, x86_64 and aarch64 Linux. PLEASE NOTE: Heap trampolines are not guaranteed to be correctly deallocated if you setjmp, instantiate nested functions, and then longjmp back to a state prior to having allocated those nested functions.

As in the note, because the trampoline can't be pushed to the stack, it instead goes on the heap, thrashing memory allocations during the `super_qromb` call. 