### PR TITLE
Procedure documentation comment consistency/typo fixes

### DIFF
--- a/bmad/code/create_lat_ele_nametable.f90
+++ b/bmad/code/create_lat_ele_nametable.f90
@@ -6,7 +6,7 @@
 ! Input:
 !   lat         -- lat_struct: Lattice.
 !
-! Ouput:
+! Output:
 !   nametable   -- nametable_struct: Nametable of the elment names
 !-
 

--- a/bmad/code/particle_rf_time.f90
+++ b/bmad/code/particle_rf_time.f90
@@ -25,7 +25,7 @@
 !   abs_time          -- real(rp), optional: If False (default) use setting of bmad_com%absolute_time_tracking.
 !                           If True, use absolute time instead of relative time.
 !
-! Ouput:
+! Output:
 !   time      -- Real(rp): Current time.
 !-
 

--- a/bmad/code/save_a_step.f90
+++ b/bmad/code/save_a_step.f90
@@ -27,7 +27,7 @@
 !                       This is only needed if save_field = True.
 !   strong_beam     -- strong_beambeam_struct, optional: Strong beam info if tracking through a beambeam element.
 !
-! Ouput:
+! Output:
 !   track           -- track_struct: Track with current position appended on.
 !-
 

--- a/bmad/hdf5/hdf5_read_grid_field.f90
+++ b/bmad/hdf5/hdf5_read_grid_field.f90
@@ -10,7 +10,7 @@
 !   combine       -- logical, optional: If False (the default), discard existing data in input g_field.
 !                     If True, output g_field(:) array combines old and new data.
 !
-! Ouput:
+! Output:
 !   g_field(:)    -- grid_field_struct, pointer: Grid field array.
 !   err_flag      -- logical: Set True if there is an error. False otherwise.
 !   pmd_header    -- pmd_header_struct, optional: Extra info like file creation date.

--- a/bmad/hdf5/hdf5_write_grid_field.f90
+++ b/bmad/hdf5/hdf5_write_grid_field.f90
@@ -9,7 +9,7 @@
 !   ele           -- ele_struct: Element associated with the map.
 !   g_field(:)    -- grid_field_struct: Grid field.
 !
-! Ouput:
+! Output:
 !   err_flag      -- logical: Set True if there is an error. False otherwise.
 !-
 

--- a/bmad/low_level/bend_length_has_been_set.f90
+++ b/bmad/low_level/bend_length_has_been_set.f90
@@ -10,7 +10,7 @@
 ! Input:
 !   ele           -- ele_struct: Element to be checked.
 !
-! Ouput:
+! Output:
 !   is_set        -- logical: Note: will be set True for non-bend elements.
 
 function bend_length_has_been_set(ele) result (is_set)

--- a/bmad/low_level/rf_ref_time_offset.f90
+++ b/bmad/low_level/rf_ref_time_offset.f90
@@ -12,7 +12,7 @@
 !   ele      -- ele_struct: RF Element being tracked through.
 !   ds       -- real(rp), optional: Distance of particle from start edge. Default is zero.
 !
-! Ouput:
+! Output:
 !   time  -- Real(rp): Offset time.
 !-
 

--- a/bmad/modules/em_field_mod.f90
+++ b/bmad/modules/em_field_mod.f90
@@ -93,7 +93,7 @@ end function g_bend_from_em_field
 !   r0(3)             -- real(rp): origin point of the fieldmap.
 !   curved_ref_frame  -- logical: If the element is a bend: Does the field map follow the bend reference coords?
 !
-! Outpt:
+! Output:
 !   x, y, z           -- real(rp): Coords relative to the field map.
 !   cos_ang, sin_ang  -- real(rp): cos and sin of coordinate rotation angle.
 !   err_flag          -- logical: Set True if there is an error. False otherwise.

--- a/bmad/multiparticle/beam_init_setup.f90
+++ b/bmad/multiparticle/beam_init_setup.f90
@@ -13,7 +13,7 @@
 !   species       -- integer: Beam particle species.
 !   modes         -- normal_modes_struct, optional: Normal mode parameters.
 !
-! Ouput:
+! Output:
 !   err_flag      -- logical, optional: Set true if there is an error. False otherwise.
 !   beam_init_set -- beam_init_struct: See above.
 !-

--- a/bmad/multiparticle/save_a_beam_step.f90
+++ b/bmad/multiparticle/save_a_beam_step.f90
@@ -12,7 +12,7 @@
 !   is_time_coords  -- logical, optional: Default is False. If True, input beam is using time coordinates in which
 !                       case there will be a conversion to s-coords before bunch_params are computed.
 !
-! Ouput:
+! Output:
 !   bunch_tracks(:) -- bunch_track_struct, optional: Track with current bunch info appended on. This routine does nothing
 !                       if this argument is not present.
 !-

--- a/bmad/multiparticle/save_a_bunch_step.f90
+++ b/bmad/multiparticle/save_a_bunch_step.f90
@@ -12,7 +12,7 @@
 !   is_time_coords  -- logical, optional: Default is False. If True, input bunch is using time coordinates in which
 !                       case there will be a conversion to s-coords before bunch_params are computed.
 !
-! Ouput:
+! Output:
 !   bunch_track     -- bunch_track_struct, optional: Track with current bunch info appended on. This routine does nothing
 !                       if this argument is not present.
 !-

--- a/bmad/old_code/hdf5_fieldmap_mod.f90.old
+++ b/bmad/old_code/hdf5_fieldmap_mod.f90.old
@@ -19,7 +19,7 @@ contains
 !   ele           -- ele_struct: Element associated with the map.
 !   cart_map      -- cartesian_map_struct: Cartesian map.
 !
-! Ouput:
+! Output:
 !   err_flag      -- logical: Set True if there is an error. False otherwise.
 !-
 
@@ -79,7 +79,7 @@ end subroutine hdf5_write_cartesian_map
 !   file_name     -- character(*): File to create.
 !   ele           -- ele_struct: Element associated with the map.
 !
-! Ouput:
+! Output:
 !   cart_map      -- cartesian_map_struct, cartesian map.
 !   err_flag      -- logical: Set True if there is an error. False otherwise.
 !-
@@ -147,7 +147,7 @@ end subroutine hdf5_read_cartesian_map
 !   ele           -- ele_struct: Element associated with the map.
 !   cl_map        -- cylindrical_map_struct: Cylindrical map.
 !
-! Ouput:
+! Output:
 !   err_flag      -- logical: Set True if there is an error. False otherwise.
 !-
 
@@ -188,7 +188,7 @@ end subroutine hdf5_write_cylindrical_map
 !   file_name     -- character(*): File to create.
 !   ele           -- ele_struct: Element associated with the map.
 !
-! Ouput:
+! Output:
 !   cl_map        -- cylindrical_map_struct, cylindrical map.
 !   err_flag      -- logical: Set True if there is an error. False otherwise.
 !-
@@ -232,7 +232,7 @@ end subroutine hdf5_read_cylindrical_map
 !   ele           -- ele_struct: Element associated with the map.
 !   g_field       -- grid_field_struct: Cylindrical map.
 !
-! Ouput:
+! Output:
 !   err_flag      -- logical: Set True if there is an error. False otherwise.
 !-
 
@@ -289,7 +289,7 @@ end subroutine hdf5_write_grid_field
 !   file_name     -- character(*): File to create.
 !   ele           -- ele_struct: Element associated with the map.
 !
-! Ouput:
+! Output:
 !   g_field       -- grid_field_struct, cylindrical map.
 !   err_flag      -- logical: Set True if there is an error. False otherwise.
 !-
@@ -333,7 +333,7 @@ end subroutine hdf5_read_grid_field
 !   ele           -- ele_struct: Element associated with the map.
 !   t_field       -- taylor_field_struct: Cylindrical map.
 !
-! Ouput:
+! Output:
 !   err_flag      -- logical: Set True if there is an error. False otherwise.
 !-
 
@@ -374,7 +374,7 @@ end subroutine hdf5_write_taylor_field
 !   file_name     -- character(*): File to create.
 !   ele           -- ele_struct: Element associated with the map.
 !
-! Ouput:
+! Output:
 !   t_field       -- taylor_field_struct, cylindrical map.
 !   err_flag      -- logical: Set True if there is an error. False otherwise.
 !-

--- a/bmad/parsing/binary_parser_mod.f90
+++ b/bmad/parsing/binary_parser_mod.f90
@@ -18,7 +18,7 @@ contains
 !   ele           -- ele_struct: Element associated with the map.
 !   cart_map      -- cartesian_map_struct: Cartesian map.
 !
-! Ouput:
+! Output:
 !   err_flag      -- logical: Set True if there is an error. False otherwise.
 !-
 
@@ -77,7 +77,7 @@ end subroutine write_binary_cartesian_map
 !   file_name     -- character(*): File to create.
 !   ele           -- ele_struct: Element associated with the map.
 !
-! Ouput:
+! Output:
 !   cart_map      -- cartesian_map_struct, cartesian map.
 !   err_flag      -- logical: Set True if there is an error. False otherwise.
 !-
@@ -142,7 +142,7 @@ end subroutine read_binary_cartesian_map
 !   ele           -- ele_struct: Element associated with the map.
 !   cl_map        -- cylindrical_map_struct: Cylindrical map.
 !
-! Ouput:
+! Output:
 !   err_flag      -- logical: Set True if there is an error. False otherwise.
 !-
 
@@ -203,7 +203,7 @@ end subroutine write_binary_cylindrical_map
 !   file_name     -- character(*): File to create.
 !   ele           -- ele_struct: Element associated with the map.
 !
-! Ouput:
+! Output:
 !   cl_map        -- cylindrical_map_struct, cylindrical map.
 !   err_flag      -- logical: Set True if there is an error. False otherwise.
 !-
@@ -268,7 +268,7 @@ end subroutine read_binary_cylindrical_map
 !   ele           -- ele_struct: Element associated with the map.
 !   g_field       -- grid_field_struct: Cylindrical map.
 !
-! Ouput:
+! Output:
 !   err_flag      -- logical: Set True if there is an error. False otherwise.
 !-
 
@@ -330,7 +330,7 @@ end subroutine write_binary_grid_field
 !   file_name     -- character(*): File to create.
 !   ele           -- ele_struct: Element associated with the map.
 !
-! Ouput:
+! Output:
 !   g_field       -- grid_field_struct, cylindrical map.
 !   err_flag      -- logical: Set True if there is an error. False otherwise.
 !-

--- a/lux/code/lux_module.f90
+++ b/lux/code/lux_module.f90
@@ -425,7 +425,7 @@ end subroutine lux_init_data
 !   lux_param   -- lux_param_struct: Lux input parameters.
 !   lux_com     -- lux_common_struct: Common parameters.
 !
-! Ouput:
+! Output:
 !   orb         -- coord_struct: Initialized starting coords.
 !-
 

--- a/sim_utils/interfaces/sim_utils_struct.f90
+++ b/sim_utils/interfaces/sim_utils_struct.f90
@@ -135,7 +135,7 @@ contains
 ! Input:
 !   logic   -- logical: logical to translate.
 !
-! Ouput:
+! Output:
 !   int     -- integer: Translated logical.
 !-
 

--- a/sim_utils/math/inverse.f90
+++ b/sim_utils/math/inverse.f90
@@ -5,7 +5,7 @@
 ! This function is a slight modification of the function ZBRENT given
 !     in Numerical Recipes.
 !
-! Inputs:
+! Input:
 !   funct(x) -- Function: Function to be inverted.
 !   y        -- Real(rp): Value to be inverted.
 !   x1, x2   -- Real(rp): X must lie between: X1 < X < X2.

--- a/sim_utils/math/max_nonzero.f90
+++ b/sim_utils/math/max_nonzero.f90
@@ -5,7 +5,7 @@
 ! with index greater than ix_max are zero. and either array1(ix_max) or array2(ix_max) 
 ! is non zero.
 !
-! Inputs:
+! Input:
 !   lbnd        -- integer: Lower bound of array1 and array2
 !   array1(:)   -- real(rp): Array of numbers.
 !   array2(:)   -- real(rp), optional: Array of numbers. 

--- a/sim_utils/matrix/qr_mod.f90
+++ b/sim_utils/matrix/qr_mod.f90
@@ -43,7 +43,7 @@ CONTAINS
 ! Input:
 !   Ain(:,:)   -- REAL(rp), INTENT(IN):  m*n, m>=n, array of reals.
 ! 
-! Ouput:
+! Output:
 !   Q(:,:)     -- Double precision m*m array of reals.
 !   R(:,:)     -- Double precision n*n array of reals.
 !-
@@ -92,7 +92,7 @@ END SUBROUTINE qr
 ! Input:
 !   Ain(:,:)   -- REAL(rp), INTENT(IN): m*n, m>=n, array of reals.
 ! 
-! Ouput:
+! Output:
 !   Q1(:,:)    -- REAL(rp), INTENT(OUT): m*n array of reals.
 !   R1(:,:)    -- REAL(rp), INTENT(OUT): n*n array of reals.
 !-

--- a/tao/code/tao_control_tree_list.f90
+++ b/tao/code/tao_control_tree_list.f90
@@ -7,7 +7,7 @@
 ! Input:
 !   ele     -- ele_struct: Lattice element to start at.
 !
-! Ouput:
+! Output:
 !   tree(:) -- ele_pointer_struct, allocatable: Array of elements.
 !-
 

--- a/tao/code/tao_evaluate_tune.f90
+++ b/tao/code/tao_evaluate_tune.f90
@@ -15,7 +15,7 @@
 !                   Also used to set the integer part of the tune.
 !   delta_input -- logical: If true then qa_str and qb_str are deltas from present tune.
 !
-! Outut:
+! Output:
 !   q_val       -- real(rp): Tune value. Set zero if there is an error.
 !-
 

--- a/tao/code/tao_pointer_to_datum.f90
+++ b/tao/code/tao_pointer_to_datum.f90
@@ -7,7 +7,7 @@
 !   d1        -- tao_d1_data_struct: D1 data struct to search.
 !   ele_name  -- character(*): Name of lattice element to match to.
 !
-! Ouput:
+! Output:
 !   datum_ptr   -- data_struct, pointer: Pointer to the matched datum. 
 !                   Will be null if no match found.
 !-

--- a/tao/code/tao_set_var_useit_opt.f90
+++ b/tao/code/tao_set_var_useit_opt.f90
@@ -4,7 +4,10 @@
 ! Calculate which variables will be used by optimizer.
 ! This is indicated by s%u(:)%var(:)%useit_opt
 !
-! Input/Output:
+! Input:
+!   s     -- type_super_universe_struct
+!
+! Output:
 !   s     -- type_super_universe_struct
 !-
 


### PR DESCRIPTION
This affects only the preceding documentation comments for procedures, ensuring that sections are labeled without typos (e.g., `Ouput:` -> `Output:`).