### PR TITLE
Fix `ele` -> `half_ele` typo, causing intermittent particle loss

### DIFF
--- a/bmad/code/create_element_slice.f90
+++ b/bmad/code/create_element_slice.f90
@@ -151,6 +151,10 @@ if (present(old_slice) .and. .not. rad_map_stale .and. .not. include_upstream_en
   case (sbend$, quadrupole$, sextupole$, octupole$, thick_multipole$)
     if (associated(sliced_ele%rad_map)) sliced_ele%rad_map%stale = .false.
   end select
+else
+  if (associated(sliced_ele%rad_map)) then
+    sliced_ele%rad_map%stale = .true.
+  endif
 endif
 
 ! For a sliced taylor element the %taylor%term components point to the lord components. 

--- a/bmad/code/create_element_slice.f90
+++ b/bmad/code/create_element_slice.f90
@@ -144,17 +144,15 @@ if (err2_flag) return
 ! See if %rad_map can be saved. Can only do this if the old_slice is the same as the new one.
 ! Therefore cannot save with wigglers and other elements which are not uniform longitudinally
 
-if (present(old_slice) .and. .not. rad_map_stale .and. .not. include_upstream_end .and. &
+if (associated(sliced_ele%rad_map) .and. present(old_slice) .and. .not. rad_map_stale .and. .not. include_upstream_end .and. &
     .not. include_downstream_end .and. ele0%value(l$) == sliced_ele%value(l$) .and. &
     (ele_in%tracking_method == bmad_standard$ .or. ele_in%field_calc == bmad_standard$)) then
   select case (ele_in%key)
   case (sbend$, quadrupole$, sextupole$, octupole$, thick_multipole$)
-    if (associated(sliced_ele%rad_map)) sliced_ele%rad_map%stale = .false.
-  end select
-else
-  if (associated(sliced_ele%rad_map)) then
+    sliced_ele%rad_map%stale = .false.
+  case default
     sliced_ele%rad_map%stale = .true.
-  endif
+  end select
 endif
 
 ! For a sliced taylor element the %taylor%term components point to the lord components. 

--- a/bmad/multiparticle/beam_utils.f90
+++ b/bmad/multiparticle/beam_utils.f90
@@ -141,7 +141,8 @@ else
   call create_element_slice (half_ele, ele, ds_wake, 0.0_rp, branch%param, .true., .false., err_flag)
 endif
 
-if (bmad_com%radiation_damping_on .or. bmad_com%radiation_fluctuations_on) call radiation_map_setup(ele, err_flag)
+if (bmad_com%radiation_damping_on .or. bmad_com%radiation_fluctuations_on) call radiation_map_setup(half_ele, err_flag)
+
 !$OMP parallel do if (thread_safe)
 do j = 1, size(bunch%particle)
   if (bunch%particle(j)%state /= alive$) cycle


### PR DESCRIPTION
Looking at the surrounding code in `bmad/multiparticle/beam_utils.f90`, it's apparent that the radiation map should be set on `half_ele` rather than `ele`. This appears to have been a copy/paste mistake.

The change in `bmad/code/create_element_slice.f90` might not be strictly necessary, but for cleanliness it seemed correct to me.

@ChristopherMayes has an isolated test case that can trigger this bug.