### PR TITLE
Optimize FFT-based space charge calculation by caching

### DIFF
--- a/bmad/modules/bmad_struct.f90
+++ b/bmad/modules/bmad_struct.f90
@@ -2169,6 +2169,10 @@ type space_charge_common_struct                   ! Common block for space charg
                                                   !   If a bin sigma is < cutoff * sigma_ave then ignore.
   real(rp) :: particle_sigma_cutoff = -1          ! 3D SC calc cutoff for particles with (x,y,z) position far from the center.
                                                   !  Negative or zero means ignore.
+  real(rp) :: mesh_growth_factor = 0.1             ! Fractional padding when growing SC mesh (default: 10%).
+                                                  !  Set to 0 for tight-fit (no caching speedup).
+  real(rp) :: mesh_shrink_factor = 0.1             ! Fractional threshold for shrinking SC mesh (default: 10%).
+                                                  !  Mesh shrinks when bunch fills < (1-this) of the mesh range.
   integer :: space_charge_mesh_size(3) = [32, 32, 64]  ! Gird size for fft_3d space charge calc.
   integer :: csr3d_mesh_size(3) = [32, 32, 64]         ! Gird size for CSR.
   integer :: n_bin = 0                            ! Number of bins used

--- a/bmad/space_charge/csr_and_space_charge_mod.f90
+++ b/bmad/space_charge/csr_and_space_charge_mod.f90
@@ -1466,7 +1466,8 @@ if (ele%space_charge_method == fft_3d$) then
     csr%position(n)%charge = p%charge
   enddo
 
-  call deposit_particles (csr%position(1:n)%r(1), csr%position(1:n)%r(2), csr%position(1:n)%r(3), csr%mesh3d, qa=csr%position(1:n)%charge)
+  call deposit_particles (csr%position(1:n)%r(1), csr%position(1:n)%r(2), csr%position(1:n)%r(3), csr%mesh3d, qa=csr%position(1:n)%charge, &
+    mesh_growth_factor=space_charge_com%mesh_growth_factor, mesh_shrink_factor=space_charge_com%mesh_shrink_factor)
   ! OLD ROUTINE: call space_charge_freespace(csr%mesh3d)
   call space_charge_3d(csr%mesh3d)
    
@@ -1728,7 +1729,8 @@ do i_step = 0, n_step
     csr%position(n)%r = p%vec(1:5:2)
     csr%position(n)%charge = p%charge
   enddo
-  call deposit_particles (csr%position(1:n)%r(1), csr%position(1:n)%r(2), csr%position(1:n)%r(3), csr%mesh3d, qa=csr%position(1:n)%charge)  
+  call deposit_particles (csr%position(1:n)%r(1), csr%position(1:n)%r(2), csr%position(1:n)%r(3), csr%mesh3d, qa=csr%position(1:n)%charge, &
+    mesh_growth_factor=space_charge_com%mesh_growth_factor, mesh_shrink_factor=space_charge_com%mesh_shrink_factor)  
 
   ! Give particles a kick
   ! TODO: simplify with fft_3d

--- a/bmad/space_charge/csr_and_space_charge_mod.f90
+++ b/bmad/space_charge/csr_and_space_charge_mod.f90
@@ -1491,6 +1491,7 @@ if (ele%space_charge_method == fft_3d$) then
     call interpolate_field_batch(x_interp, y_interp, z_interp, csr%mesh3d, n_interp, E=E_batch)
 
     ! Apply kicks
+    !$OMP PARALLEL DO PRIVATE(n, i, p, factor, pz0, ef, dpz, new_beta)
     do n = 1, n_interp
       i = interp_idx(n)
       p => particle(i)
@@ -1506,6 +1507,7 @@ if (ele%space_charge_method == fft_3d$) then
       p%vec(5) = p%vec(5) * new_beta / p%beta
       p%beta = new_beta
     enddo
+    !$OMP END PARALLEL DO
   endif
 
   deallocate(x_interp, y_interp, z_interp, interp_idx, E_batch)

--- a/bmad/space_charge/csr_and_space_charge_mod.f90
+++ b/bmad/space_charge/csr_and_space_charge_mod.f90
@@ -1349,7 +1349,10 @@ type (csr_bunch_slice_struct), pointer :: slice
 
 real(rp) zp, r1, r0, dz, dpz, nk(2), dnk(2,2), f0, f, beta0, dpx, dpy, x, y, f_tot
 real(rp) Evec(3), factor, pz0, dct_ave, new_beta, ef
-integer i, n, i0, i_del, ip
+integer i, n, i0, i_del, ip, n_interp
+! Batch interpolation arrays for fft_3d
+real(rp), allocatable :: x_interp(:), y_interp(:), z_interp(:), E_batch(:,:)
+integer, allocatable :: interp_idx(:)
 
 ! CSR kick and Slice space charge kick
 ! We use a weighted average so that the integral varies smoothly as a function of particle%vec(5).
@@ -1470,24 +1473,42 @@ if (ele%space_charge_method == fft_3d$) then
     mesh_growth_factor=space_charge_com%mesh_growth_factor, mesh_shrink_factor=space_charge_com%mesh_shrink_factor)
   ! OLD ROUTINE: call space_charge_freespace(csr%mesh3d)
   call space_charge_3d(csr%mesh3d)
-   
+
+  ! Batch interpolation: gather coordinates for alive particles
+  allocate(x_interp(size(particle)), y_interp(size(particle)), z_interp(size(particle)))
+  allocate(interp_idx(size(particle)), E_batch(3, size(particle)))
+  n_interp = 0
   do i = 1, size(particle)
-    p => particle(i)
-    if (p%state /= alive$) cycle
-    call interpolate_field(p%vec(1), p%vec(3), p%vec(5)-dct_ave*p%beta,  csr%mesh3d, E=Evec)
-    factor = csr%actual_track_step / (p%p0c  * p%beta) 
-    pz0 = sqrt( (1.0_rp + p%vec(6))**2 - p%vec(2)**2 - p%vec(4)**2 ) ! * p0 
-    ! Considering magnetic field also, effectively reduces this force by 1/gamma^2
-    p%vec(2) = p%vec(2) + Evec(1)*factor / csr%mesh3d%gamma**2
-    p%vec(4) = p%vec(4) + Evec(2)*factor / csr%mesh3d%gamma**2
-    ef = Evec(3) * factor
-    dpz = sqrt_alpha(1 + p%vec(6), ef*ef + 2 * ef * pz0)  ! = sqrt((ef + pz0)^2 + p%vec(2)**2 + p%vec(4)**2) - (1 + p%vec(6))
-    p%vec(6) = p%vec(6) + dpz
-    ! Set beta
-    call convert_pc_to (p%p0c * (1 + p%vec(6)), p%species, beta = new_beta)
-    p%vec(5) = p%vec(5) * new_beta / p%beta
-    p%beta = new_beta
+    if (particle(i)%state /= alive$) cycle
+    n_interp = n_interp + 1
+    x_interp(n_interp) = particle(i)%vec(1)
+    y_interp(n_interp) = particle(i)%vec(3)
+    z_interp(n_interp) = particle(i)%vec(5) - dct_ave * particle(i)%beta
+    interp_idx(n_interp) = i
   enddo
+
+  if (n_interp > 0) then
+    call interpolate_field_batch(x_interp, y_interp, z_interp, csr%mesh3d, n_interp, E=E_batch)
+
+    ! Apply kicks
+    do n = 1, n_interp
+      i = interp_idx(n)
+      p => particle(i)
+      factor = csr%actual_track_step / (p%p0c * p%beta)
+      pz0 = sqrt((1.0_rp + p%vec(6))**2 - p%vec(2)**2 - p%vec(4)**2)
+      ! Considering magnetic field also, effectively reduces this force by 1/gamma^2
+      p%vec(2) = p%vec(2) + E_batch(1,n) * factor / csr%mesh3d%gamma**2
+      p%vec(4) = p%vec(4) + E_batch(2,n) * factor / csr%mesh3d%gamma**2
+      ef = E_batch(3,n) * factor
+      dpz = sqrt_alpha(1 + p%vec(6), ef*ef + 2 * ef * pz0)
+      p%vec(6) = p%vec(6) + dpz
+      call convert_pc_to (p%p0c * (1 + p%vec(6)), p%species, beta = new_beta)
+      p%vec(5) = p%vec(5) * new_beta / p%beta
+      p%beta = new_beta
+    enddo
+  endif
+
+  deallocate(x_interp, y_interp, z_interp, interp_idx, E_batch)
 endif
 
 end subroutine csr_and_sc_apply_kicks

--- a/bmad/space_charge/csr_and_space_charge_mod.f90
+++ b/bmad/space_charge/csr_and_space_charge_mod.f90
@@ -1349,10 +1349,7 @@ type (csr_bunch_slice_struct), pointer :: slice
 
 real(rp) zp, r1, r0, dz, dpz, nk(2), dnk(2,2), f0, f, beta0, dpx, dpy, x, y, f_tot
 real(rp) Evec(3), factor, pz0, dct_ave, new_beta, ef
-integer i, n, i0, i_del, ip, n_interp
-! Batch interpolation arrays for fft_3d
-real(rp), allocatable :: x_interp(:), y_interp(:), z_interp(:), E_batch(:,:)
-integer, allocatable :: interp_idx(:)
+integer i, n, i0, i_del, ip
 
 ! CSR kick and Slice space charge kick
 ! We use a weighted average so that the integral varies smoothly as a function of particle%vec(5).
@@ -1449,71 +1446,106 @@ endif
 ! Mesh Space charge kick
 
 if (ele%space_charge_method == fft_3d$) then
-  if (.not. allocated(csr%position)) allocate(csr%position(size(particle)))
-  if (size(csr%position) < size(particle)) then
-    deallocate(csr%position)
-    allocate(csr%position(size(particle)))
-  endif
-
-  ! Do the calculation with respect to the average of (time - time_ref) so that adding a constant time offset
-  ! will not affect the calculation.
-
-  dct_ave = sum(particle%vec(5)/particle%beta, particle%state == alive$) / count(particle%state == alive$)
-
-  n = 0
-  do i = 1, size(particle)
-    p => particle(i)
-    if (p%state /= alive$) cycle
-    n = n + 1
-    csr%position(n)%r = [p%vec(1), p%vec(3), p%vec(5) - dct_ave * p%beta]
-    csr%position(n)%charge = p%charge
-  enddo
-
-  call deposit_particles (csr%position(1:n)%r(1), csr%position(1:n)%r(2), csr%position(1:n)%r(3), csr%mesh3d, qa=csr%position(1:n)%charge, &
-    mesh_growth_factor=space_charge_com%mesh_growth_factor, mesh_shrink_factor=space_charge_com%mesh_shrink_factor)
-  ! OLD ROUTINE: call space_charge_freespace(csr%mesh3d)
-  call space_charge_3d(csr%mesh3d)
-
-  ! Batch interpolation: gather coordinates for alive particles
-  allocate(x_interp(size(particle)), y_interp(size(particle)), z_interp(size(particle)))
-  allocate(interp_idx(size(particle)), E_batch(3, size(particle)))
-  n_interp = 0
-  do i = 1, size(particle)
-    if (particle(i)%state /= alive$) cycle
-    n_interp = n_interp + 1
-    x_interp(n_interp) = particle(i)%vec(1)
-    y_interp(n_interp) = particle(i)%vec(3)
-    z_interp(n_interp) = particle(i)%vec(5) - dct_ave * particle(i)%beta
-    interp_idx(n_interp) = i
-  enddo
-
-  if (n_interp > 0) then
-    call interpolate_field_batch(x_interp, y_interp, z_interp, csr%mesh3d, n_interp, E=E_batch)
-
-    ! Apply kicks
-    !$OMP PARALLEL DO PRIVATE(n, i, p, factor, pz0, ef, dpz, new_beta)
-    do n = 1, n_interp
-      i = interp_idx(n)
-      p => particle(i)
-      factor = csr%actual_track_step / (p%p0c * p%beta)
-      pz0 = sqrt((1.0_rp + p%vec(6))**2 - p%vec(2)**2 - p%vec(4)**2)
-      ! Considering magnetic field also, effectively reduces this force by 1/gamma^2
-      p%vec(2) = p%vec(2) + E_batch(1,n) * factor / csr%mesh3d%gamma**2
-      p%vec(4) = p%vec(4) + E_batch(2,n) * factor / csr%mesh3d%gamma**2
-      ef = E_batch(3,n) * factor
-      dpz = sqrt_alpha(1 + p%vec(6), ef*ef + 2 * ef * pz0)
-      p%vec(6) = p%vec(6) + dpz
-      call convert_pc_to (p%p0c * (1 + p%vec(6)), p%species, beta = new_beta)
-      p%vec(5) = p%vec(5) * new_beta / p%beta
-      p%beta = new_beta
-    enddo
-    !$OMP END PARALLEL DO
-  endif
-
-  deallocate(x_interp, y_interp, z_interp, interp_idx, E_batch)
+  call apply_fft_3d_kicks(csr, particle)
 endif
 
 end subroutine csr_and_sc_apply_kicks
+
+!----------------------------------------------------------------------------
+!----------------------------------------------------------------------------
+!----------------------------------------------------------------------------
+!+
+! Subroutine apply_fft_3d_kicks (csr, particle)
+!
+! Routine to apply FFT-based 3D space charge kicks to particles.
+! Deposits charge on a mesh, solves for the field, interpolates back, and applies kicks.
+!
+! Input:
+!   csr         -- csr_struct: Contains mesh, position arrays, and tracking parameters.
+!   particle(:) -- coord_struct: Particles to kick.
+!
+! Output:
+!   particle(:) -- coord_struct: Particles with kicks applied.
+!-
+
+subroutine apply_fft_3d_kicks (csr, particle)
+
+implicit none
+
+type (csr_struct), target :: csr
+type (coord_struct), target :: particle(:)
+type (coord_struct), pointer :: p
+
+real(rp) :: dct_ave, factor, pz0, ef, dpz, new_beta
+integer :: i, n, n_interp
+real(rp), allocatable :: x_interp(:), y_interp(:), z_interp(:), E_batch(:,:)
+integer, allocatable :: interp_idx(:)
+
+!
+
+if (.not. allocated(csr%position)) allocate(csr%position(size(particle)))
+if (size(csr%position) < size(particle)) then
+  deallocate(csr%position)
+  allocate(csr%position(size(particle)))
+endif
+
+! Do the calculation with respect to the average of (time - time_ref) so that adding a constant time offset
+! will not affect the calculation.
+
+dct_ave = sum(particle%vec(5)/particle%beta, particle%state == alive$) / count(particle%state == alive$)
+
+n = 0
+do i = 1, size(particle)
+  p => particle(i)
+  if (p%state /= alive$) cycle
+  n = n + 1
+  csr%position(n)%r = [p%vec(1), p%vec(3), p%vec(5) - dct_ave * p%beta]
+  csr%position(n)%charge = p%charge
+enddo
+
+call deposit_particles (csr%position(1:n)%r(1), csr%position(1:n)%r(2), csr%position(1:n)%r(3), csr%mesh3d, qa=csr%position(1:n)%charge, &
+  mesh_growth_factor=space_charge_com%mesh_growth_factor, mesh_shrink_factor=space_charge_com%mesh_shrink_factor)
+call space_charge_3d(csr%mesh3d)
+
+! Gather coordinates for alive particles
+allocate(x_interp(size(particle)), y_interp(size(particle)), z_interp(size(particle)))
+allocate(interp_idx(size(particle)), E_batch(3, size(particle)))
+n_interp = 0
+do i = 1, size(particle)
+  if (particle(i)%state /= alive$) cycle
+  n_interp = n_interp + 1
+  x_interp(n_interp) = particle(i)%vec(1)
+  y_interp(n_interp) = particle(i)%vec(3)
+  z_interp(n_interp) = particle(i)%vec(5) - dct_ave * particle(i)%beta
+  interp_idx(n_interp) = i
+enddo
+
+! Batch interpolation and kick application
+if (n_interp > 0) then
+  call interpolate_field_batch(x_interp, y_interp, z_interp, csr%mesh3d, n_interp, E=E_batch)
+
+  !$OMP PARALLEL DO PRIVATE(n, i, p, factor, pz0, ef, dpz, new_beta)
+  do n = 1, n_interp
+    i = interp_idx(n)
+    p => particle(i)
+    factor = csr%actual_track_step / (p%p0c * p%beta)
+    pz0 = sqrt((1.0_rp + p%vec(6))**2 - p%vec(2)**2 - p%vec(4)**2)
+    ! Considering magnetic field also, effectively reduces this force by 1/gamma^2
+    p%vec(2) = p%vec(2) + E_batch(1,n) * factor / csr%mesh3d%gamma**2
+    p%vec(4) = p%vec(4) + E_batch(2,n) * factor / csr%mesh3d%gamma**2
+    ef = E_batch(3,n) * factor
+    dpz = sqrt_alpha(1 + p%vec(6), ef*ef + 2 * ef * pz0)
+    p%vec(6) = p%vec(6) + dpz
+    call convert_pc_to (p%p0c * (1 + p%vec(6)), p%species, beta = new_beta)
+    p%vec(5) = p%vec(5) * new_beta / p%beta
+    p%beta = new_beta
+  enddo
+  !$OMP END PARALLEL DO
+endif
+
+deallocate(x_interp, y_interp, z_interp, interp_idx, E_batch)
+
+end subroutine apply_fft_3d_kicks
 
 !----------------------------------------------------------------------------
 !----------------------------------------------------------------------------

--- a/bmad/space_charge/fft_interface_mod.f90
+++ b/bmad/space_charge/fft_interface_mod.f90
@@ -107,16 +107,41 @@ end
 !end subroutine
 
 
-subroutine ccfft3d(a,b,idir,n1,n2,n3,iskiptrans)
+subroutine fft_cache_init()
 use, intrinsic :: iso_c_binding
 use omp_lib
 implicit none
 include 'fftw3.f03'
+integer :: n_threads
+logical, save :: initialized = .false.
+! Thread safety: guard module-level state with OMP CRITICAL in case this is
+! ever called from a parallel region. fftw_plan_with_nthreads is not thread-safe.
+!$OMP CRITICAL (fft_cache_init_lock)
+if (.not. initialized) then
+  initialized = .true.
+  !$ n_threads = omp_get_max_threads()
+  !$ if (n_threads > 1) call fftw_plan_with_nthreads(n_threads)
+endif
+!$OMP END CRITICAL (fft_cache_init_lock)
+end subroutine
+
+
+subroutine ccfft3d(a,b,idir,n1,n2,n3,iskiptrans)
+use, intrinsic :: iso_c_binding
+implicit none
+include 'fftw3.f03'
 
 integer :: idir(3)
-type(C_PTR) :: plan
 complex(C_DOUBLE_COMPLEX), dimension(:,:,:) ::a, b
-integer :: dir, fdir, n1, n2, n3, iskiptrans, n_threads
+integer :: fdir, n1, n2, n3, iskiptrans
+
+! Cached plan state
+type(C_PTR), save :: plan_fwd = C_NULL_PTR
+type(C_PTR), save :: plan_bwd = C_NULL_PTR
+integer, save :: cached_n1 = 0, cached_n2 = 0, cached_n3 = 0
+complex(C_DOUBLE_COMPLEX), allocatable, save :: plan_buf(:,:,:)
+
+call fft_cache_init()
 
 if (idir(1) == 1) then
   fdir = FFTW_BACKWARD
@@ -124,18 +149,25 @@ else
   fdir = FFTW_FORWARD
 endif
 
-!$ n_threads = omp_get_max_threads()
-!$ if (n_threads > 1) then
-!! !$   print *, '  FFTW with n_threads: ', n_threads
-!$   call fftw_plan_with_nthreads(n_threads)
-!$ endif
+! Rebuild plans if mesh dimensions changed.
+! Thread safety: guard with OMP CRITICAL since FFTW plan creation is not thread-safe.
+!$OMP CRITICAL (fft_plan_cache_lock)
+if (n1 /= cached_n1 .or. n2 /= cached_n2 .or. n3 /= cached_n3) then
+  if (C_ASSOCIATED(plan_fwd)) call fftw_destroy_plan(plan_fwd)
+  if (C_ASSOCIATED(plan_bwd)) call fftw_destroy_plan(plan_bwd)
+  if (allocated(plan_buf)) deallocate(plan_buf)
+  allocate(plan_buf(n1, n2, n3))
+  plan_fwd = fftw_plan_dft_3d(n3, n2, n1, plan_buf, plan_buf, FFTW_FORWARD,  FFTW_MEASURE)
+  plan_bwd = fftw_plan_dft_3d(n3, n2, n1, plan_buf, plan_buf, FFTW_BACKWARD, FFTW_MEASURE)
+  cached_n1 = n1; cached_n2 = n2; cached_n3 = n3
+endif
+!$OMP END CRITICAL (fft_plan_cache_lock)
 
-plan = fftw_plan_dft_3d(n3,n2,n1, a,b, fdir,FFTW_ESTIMATE)
-call fftw_execute_dft(plan,a, b)
-call fftw_destroy_plan(plan)
-
-!$ if (n_threads > 1) call fftw_cleanup_threads()
-
+if (fdir == FFTW_FORWARD) then
+  call fftw_execute_dft(plan_fwd, a, b)
+else
+  call fftw_execute_dft(plan_bwd, a, b)
+endif
 
 end subroutine
 

--- a/bmad/space_charge/open_spacecharge_mod.f90
+++ b/bmad/space_charge/open_spacecharge_mod.f90
@@ -549,8 +549,9 @@ real(dp), intent(in) :: gamma, delta(3)
 real(dp), optional, intent(out), dimension(:,:,:,:) :: efield
 real(dp), optional, intent(out), dimension(:,:,:) :: phi
 real(dp), intent(in), optional :: offset(3)
-! internal arrays
-complex(dp), allocatable, dimension(:,:,:) :: crho, cgrn
+! Persistent scratch arrays — only reallocated when doubled mesh size changes
+complex(dp), allocatable, save, dimension(:,:,:) :: crho, cgrn
+integer, save :: alloc_nx2 = 0, alloc_ny2 = 0, alloc_nz2 = 0
 real(dp) :: factr, offset0=0
 real(dp), parameter :: clight=299792458.0
 real(dp), parameter :: fpei=299792458.0**2*1.00000000055d-7  ! this is 1/(4 pi eps0) after the 2019 SI changes
@@ -562,9 +563,17 @@ integer :: icomp, ishift, jshift, kshift
 nx = size(rho, 1); ny = size(rho, 2); nz = size(rho, 3)
 nx2 = 2*nx; ny2 = 2*ny; nz2 = 2*nz; 
 
-! Allocate complex scratch arrays
-allocate(crho(nx2, ny2, nz2))
-allocate(cgrn(nx2, ny2, nz2))
+! Allocate complex scratch arrays only when size changes.
+! Thread safety: guard with OMP CRITICAL in case this is ever called from a parallel region.
+!$OMP CRITICAL (solver2_scratch_lock)
+if (nx2 /= alloc_nx2 .or. ny2 /= alloc_ny2 .or. nz2 /= alloc_nz2) then
+  if (allocated(crho)) deallocate(crho)
+  if (allocated(cgrn)) deallocate(cgrn)
+  allocate(crho(nx2, ny2, nz2))
+  allocate(cgrn(nx2, ny2, nz2))
+  alloc_nx2 = nx2; alloc_ny2 = ny2; alloc_nz2 = nz2
+endif
+!$OMP END CRITICAL (solver2_scratch_lock)
 
 ! rho -> crho -> FFT(crho)
 crho = 0

--- a/bmad/space_charge/open_spacecharge_mod.f90
+++ b/bmad/space_charge/open_spacecharge_mod.f90
@@ -11,12 +11,6 @@ implicit none
 integer, parameter, private :: dp = REAL64
 !integer, parameter, private :: qp = REAL128
 
-! Saved mesh geometry for lazy resizing across calls to deposit_particles.
-! Persists between calls so delta stays constant when the bunch barely changes.
-real(dp), save, private :: saved_mesh_min(3) = 0
-real(dp), save, private :: saved_mesh_max(3) = 0
-logical, save, private :: saved_mesh_valid = .false.
-
 type mesh3d_struct
   integer :: nlo(3) = [ 1,  1,  1]       ! Lowest  grid index in x, y, z (m) of rho and the quantity being computed (phi or E)
   integer :: nhi(3) = [64, 64, 64]       ! Highest grid index in x, y, z (m) of rho and the quantity being computed (phi or E)
@@ -179,6 +173,11 @@ integer :: i, ilo, jlo, klo, ihi, jhi, khi, nlo(3), nhi(3)
 integer :: n,ip,jp,kp, n_particles
 real(dp), allocatable :: rho_priv(:,:,:)
 
+! Saved mesh geometry for lazy resizing. Persists between calls so delta
+! stays constant when the bunch barely changes, enabling Green function caching.
+real(dp), save :: saved_mesh_min(3) = 0, saved_mesh_max(3) = 0
+logical, save :: saved_mesh_valid = .false.
+
 if (present(resize_mesh)) then
     resize = resize_mesh
 else
@@ -255,7 +254,6 @@ if (allocated(mesh3d%rho)) then
   enddo
   
   if (.not. good_mesh_sizes) then
-   ! print *, 'mesh size changed, deallocating'
     deallocate(mesh3d%rho)
     deallocate(mesh3d%phi)
     deallocate(mesh3d%efield)
@@ -266,7 +264,6 @@ endif
 if (.not. allocated(mesh3d%rho)) then
   nlo = mesh3d%nlo
   nhi = mesh3d%nhi 
-  !print *, 'Allocating new meshes, nlo, nhi: ', nlo, nhi
   allocate(mesh3d%rho(nlo(1):nhi(1),nlo(2):nhi(2), nlo(3):nhi(3)))
   allocate(mesh3d%phi(nlo(1):nhi(1),nlo(2):nhi(2), nlo(3):nhi(3)))
   allocate(mesh3d%efield(nlo(1):nhi(1),nlo(2):nhi(2), nlo(3):nhi(3), 3))
@@ -926,7 +923,6 @@ if (present(offset)) then
   wmin = wmin + offset(3)*gamma ! Don't forget this!
 endif
 
-! !$ print *, 'OpenMP Green function calc osc_get_cgrn_freespace'
 !$OMP PARALLEL DO &
 !$OMP DEFAULT(FIRSTPRIVATE), &
 !$OMP SHARED(cgrn)

--- a/bmad/space_charge/open_spacecharge_mod.f90
+++ b/bmad/space_charge/open_spacecharge_mod.f90
@@ -193,32 +193,39 @@ if (resize) then
   min = [minval(xa), minval(ya), minval(za)]
   max = [maxval(xa), maxval(ya), maxval(za)]
 
-  ! Lazy resize: only change mesh bounds when the bunch no longer fits or is much smaller.
-  ! This keeps delta stable across calls, enabling Green function FFT caching.
-  needs_resize = .not. saved_mesh_valid
-  if (.not. needs_resize) then
-    ! Grow: bunch exceeds saved mesh bounds
-    if (any(min < saved_mesh_min) .or. any(max > saved_mesh_max)) then
-      needs_resize = .true.
-    else
-      ! Shrink: bunch range significantly smaller than mesh range in any dimension
-      delta = saved_mesh_max - saved_mesh_min  ! reuse delta temporarily for mesh_range
-      if (any(max - min < delta * (1.0_dp - shrink_factor))) needs_resize = .true.
-    endif
-  endif
-
-  if (needs_resize) then
-    pad = (max - min) * (growth_factor * 0.5_dp)
-    ! Ensure minimum padding for numerical safety (handles zero-range dimensions)
-    where (pad < 1.0e-10_dp) pad = 1.0e-6_dp
-    min = min - pad
-    max = max + pad
-    saved_mesh_min = min
-    saved_mesh_max = max
-    saved_mesh_valid = .true.
+  if (growth_factor == 0 .and. shrink_factor == 0) then
+    ! Original tight-fit behavior: compute delta, add tiny relative padding.
+    delta = (max - min) / (mesh3d%nhi - mesh3d%nlo)
+    min = min - 1.0e-6_dp * delta
+    max = max + 1.0e-6_dp * delta
   else
-    min = saved_mesh_min
-    max = saved_mesh_max
+    ! Lazy resize: only change mesh bounds when the bunch no longer fits or is much smaller.
+    ! This keeps delta stable across calls, enabling Green function FFT caching.
+    needs_resize = .not. saved_mesh_valid
+    if (.not. needs_resize) then
+      ! Grow: bunch exceeds saved mesh bounds
+      if (any(min < saved_mesh_min) .or. any(max > saved_mesh_max)) then
+        needs_resize = .true.
+      else
+        ! Shrink: bunch range significantly smaller than mesh range in any dimension
+        delta = saved_mesh_max - saved_mesh_min  ! reuse delta temporarily for mesh_range
+        if (any(max - min < delta * (1.0_dp - shrink_factor))) needs_resize = .true.
+      endif
+    endif
+
+    if (needs_resize) then
+      pad = (max - min) * (growth_factor * 0.5_dp)
+      ! Ensure minimum padding for numerical safety (handles zero-range dimensions)
+      where (pad < 1.0e-10_dp) pad = 1.0e-6_dp
+      min = min - pad
+      max = max + pad
+      saved_mesh_min = min
+      saved_mesh_max = max
+      saved_mesh_valid = .true.
+    else
+      min = saved_mesh_min
+      max = saved_mesh_max
+    endif
   endif
 
   delta = (max - min) / (mesh3d%nhi - mesh3d%nlo)

--- a/bmad/space_charge/open_spacecharge_mod.f90
+++ b/bmad/space_charge/open_spacecharge_mod.f90
@@ -11,6 +11,12 @@ implicit none
 integer, parameter, private :: dp = REAL64
 !integer, parameter, private :: qp = REAL128
 
+! Saved mesh geometry for lazy resizing across calls to deposit_particles.
+! Persists between calls so delta stays constant when the bunch barely changes.
+real(dp), save, private :: saved_mesh_min(3) = 0
+real(dp), save, private :: saved_mesh_max(3) = 0
+logical, save, private :: saved_mesh_valid = .false.
+
 type mesh3d_struct
   integer :: nlo(3) = [ 1,  1,  1]       ! Lowest  grid index in x, y, z (m) of rho and the quantity being computed (phi or E)
   integer :: nhi(3) = [64, 64, 64]       ! Highest grid index in x, y, z (m) of rho and the quantity being computed (phi or E)
@@ -133,18 +139,20 @@ end subroutine
 !------------------------------------------------------------------------
 !------------------------------------------------------------------------
 !+
-! Subroutine deposit_particles(xa, ya, za, mesh3d, total_charge, qa, resize_mesh)
+! Subroutine deposit_particles(xa, ya, za, mesh3d, total_charge, qa, resize_mesh, mesh_growth_factor, mesh_shrink_factor)
 !
 ! Deposits particle arrays onto mesh
 !
 ! Input:
-!   xa           -- REAL64: x coordinate array
-!   ya           -- REAL64: y coordinate array
-!   za           -- REAL64: z coordinate array
-!   qa           -- REAL64, optional: charge coordinate array
-!   total_charge -- REAL64, optional: total charge of particles, used only if qa is not present
-!   resize_mesh  -- logical, optional : Set mesh bounds to fit bunch. 
-!                            default  : .true.
+!   xa                  -- REAL64: x coordinate array
+!   ya                  -- REAL64: y coordinate array
+!   za                  -- REAL64: z coordinate array
+!   qa                  -- REAL64, optional: charge coordinate array
+!   total_charge        -- REAL64, optional: total charge of particles, used only if qa is not present
+!   resize_mesh         -- logical, optional : Set mesh bounds to fit bunch. 
+!                                   default  : .true.
+!   mesh_growth_factor  -- REAL64, optional: Fractional padding when growing mesh (default: 0 = tight fit).
+!   mesh_shrink_factor  -- REAL64, optional: Fractional threshold for shrinking mesh (default: 0 = tight fit).
 !
 ! Output:
 !   mesh3d      -- mesh3d_struct:   
@@ -154,13 +162,15 @@ end subroutine
 !-
 
 !routine for charge deposition
-subroutine deposit_particles(xa, ya, za, mesh3d, qa, total_charge, resize_mesh)
+subroutine deposit_particles(xa, ya, za, mesh3d, qa, total_charge, resize_mesh, mesh_growth_factor, mesh_shrink_factor)
 
 real(dp) :: xa(:),ya(:),za(:)
 type(mesh3d_struct) :: mesh3d
 real(dp), optional :: qa(:), total_charge
 logical, optional :: resize_mesh
-logical :: resize, good_mesh_sizes
+real(dp), intent(in), optional :: mesh_growth_factor, mesh_shrink_factor
+logical :: resize, good_mesh_sizes, needs_resize
+real(dp) :: growth_factor, shrink_factor
 
 real(dp) :: dx,dy,dz,xmin,ymin,zmin, xmax,ymax,zmax, charge1, min(3), max(3), delta(3), pad(3)
 real(dp) :: dxi,dyi,dzi,ab,de,gh
@@ -174,16 +184,44 @@ else
     resize = .true.
 endif
 
+growth_factor = 0
+if (present(mesh_growth_factor)) growth_factor = mesh_growth_factor
+shrink_factor = 0
+if (present(mesh_shrink_factor)) shrink_factor = mesh_shrink_factor
+
 if (resize) then
   min = [minval(xa), minval(ya), minval(za)]
-  max = [maxval(xa), maxval(ya), maxval(za)] 
-  delta =(max(:) - min(:) ) / (mesh3d%nhi(:) - mesh3d%nlo(:) )
-  
-  ! Small padding to protect against indexing errors
-  min = min - 1.0e-6_dp*delta
-  max = max + 1.0e-6_dp*delta
-  delta =(max(:) - min(:) ) / (mesh3d%nhi(:) - mesh3d%nlo(:) )
-  
+  max = [maxval(xa), maxval(ya), maxval(za)]
+
+  ! Lazy resize: only change mesh bounds when the bunch no longer fits or is much smaller.
+  ! This keeps delta stable across calls, enabling Green function FFT caching.
+  needs_resize = .not. saved_mesh_valid
+  if (.not. needs_resize) then
+    ! Grow: bunch exceeds saved mesh bounds
+    if (any(min < saved_mesh_min) .or. any(max > saved_mesh_max)) then
+      needs_resize = .true.
+    else
+      ! Shrink: bunch range significantly smaller than mesh range in any dimension
+      delta = saved_mesh_max - saved_mesh_min  ! reuse delta temporarily for mesh_range
+      if (any(max - min < delta * (1.0_dp - shrink_factor))) needs_resize = .true.
+    endif
+  endif
+
+  if (needs_resize) then
+    pad = (max - min) * (growth_factor * 0.5_dp)
+    ! Ensure minimum padding for numerical safety (handles zero-range dimensions)
+    where (pad < 1.0e-10_dp) pad = 1.0e-6_dp
+    min = min - pad
+    max = max + pad
+    saved_mesh_min = min
+    saved_mesh_max = max
+    saved_mesh_valid = .true.
+  else
+    min = saved_mesh_min
+    max = saved_mesh_max
+  endif
+
+  delta = (max - min) / (mesh3d%nhi - mesh3d%nlo)
   mesh3d%min = min
   mesh3d%max = max
   mesh3d%delta = delta
@@ -552,12 +590,20 @@ real(dp), intent(in), optional :: offset(3)
 ! Persistent scratch arrays — only reallocated when doubled mesh size changes
 complex(dp), allocatable, save, dimension(:,:,:) :: crho, cgrn
 integer, save :: alloc_nx2 = 0, alloc_ny2 = 0, alloc_nz2 = 0
-real(dp) :: factr, offset0=0
+! Green function FFT cache — avoids recomputing when (delta, gamma, offset, mesh size) unchanged
+complex(dp), allocatable, save, dimension(:,:,:,:) :: grn_fft_cache  ! (nx2, ny2, nz2, 0:3)
+real(dp), save :: grn_cache_delta(3) = 0
+real(dp), save :: grn_cache_gamma = -1
+real(dp), save :: grn_cache_offset(3) = 0
+integer, save :: grn_cache_nx2 = 0, grn_cache_ny2 = 0, grn_cache_nz2 = 0
+logical, save :: grn_cache_valid(0:3) = .false.
+real(dp) :: factr, offset_eff(3)
 real(dp), parameter :: clight=299792458.0
 real(dp), parameter :: fpei=299792458.0**2*1.00000000055d-7  ! this is 1/(4 pi eps0) after the 2019 SI changes
 
 integer :: nx, ny, nz, nx2, ny2, nz2
 integer :: icomp, ishift, jshift, kshift
+logical :: cache_hit
 
 ! Sizes
 nx = size(rho, 1); ny = size(rho, 2); nz = size(rho, 3)
@@ -575,6 +621,34 @@ if (nx2 /= alloc_nx2 .or. ny2 /= alloc_ny2 .or. nz2 /= alloc_nz2) then
 endif
 !$OMP END CRITICAL (solver2_scratch_lock)
 
+! Effective offset (treat absent as zero for cache key)
+if (present(offset)) then
+  offset_eff = offset
+else
+  offset_eff = 0
+endif
+
+! Check if Green function FFT cache is valid for current parameters
+cache_hit = (nx2 == grn_cache_nx2 .and. ny2 == grn_cache_ny2 .and. nz2 == grn_cache_nz2 .and. &
+             all(delta == grn_cache_delta) .and. gamma == grn_cache_gamma .and. &
+             all(offset_eff == grn_cache_offset))
+if (.not. cache_hit) then
+  grn_cache_valid = .false.
+  grn_cache_delta = delta
+  grn_cache_gamma = gamma
+  grn_cache_offset = offset_eff
+  grn_cache_nx2 = nx2; grn_cache_ny2 = ny2; grn_cache_nz2 = nz2
+  if (allocated(grn_fft_cache)) then
+    if (size(grn_fft_cache, 1) /= nx2 .or. size(grn_fft_cache, 2) /= ny2 .or. &
+        size(grn_fft_cache, 3) /= nz2) then
+      deallocate(grn_fft_cache)
+      allocate(grn_fft_cache(nx2, ny2, nz2, 0:3))
+    endif
+  else
+    allocate(grn_fft_cache(nx2, ny2, nz2, 0:3))
+  endif
+endif
+
 ! rho -> crho -> FFT(crho)
 crho = 0
 crho(1:nx, 1:ny, 1:nz) = rho ! Place in one octant
@@ -585,13 +659,17 @@ do icomp=0, 3
   if ((icomp == 0) .and. (.not. present(phi))) cycle
   if ((icomp == 1) .and. (.not. present(efield))) exit
 
-  call osc_get_cgrn_freespace(cgrn, delta, gamma, icomp, offset=offset)
-  
-  !  cgrn -> FFT(cgrn)
-  call ccfft3d(cgrn, cgrn, [1,1,1], nx2, ny2, nz2, 0)  
-  
-  ! Multiply FFT'd arrays, re-use cgrn
-  cgrn=crho*cgrn
+  if (grn_cache_valid(icomp)) then
+    ! Cache hit: multiply directly from cached FFT'd Green function
+    cgrn = crho * grn_fft_cache(:,:,:,icomp)
+  else
+    ! Cache miss: compute Green function, forward FFT, cache, multiply
+    call osc_get_cgrn_freespace(cgrn, delta, gamma, icomp, offset=offset_eff)
+    call ccfft3d(cgrn, cgrn, [1,1,1], nx2, ny2, nz2, 0)
+    grn_fft_cache(:,:,:,icomp) = cgrn
+    grn_cache_valid(icomp) = .true.
+    cgrn = crho * cgrn
+  endif
 
   ! Inverse FFT
   call ccfft3d(cgrn, cgrn, [-1,-1,-1], nx2, ny2, nz2, 0)  

--- a/bmad/space_charge/open_spacecharge_mod.f90
+++ b/bmad/space_charge/open_spacecharge_mod.f90
@@ -174,8 +174,10 @@ real(dp) :: growth_factor, shrink_factor
 
 real(dp) :: dx,dy,dz,xmin,ymin,zmin, xmax,ymax,zmax, charge1, min(3), max(3), delta(3), pad(3)
 real(dp) :: dxi,dyi,dzi,ab,de,gh
+real(dp) :: oab  ! 1-ab
 integer :: i, ilo, jlo, klo, ihi, jhi, khi, nlo(3), nhi(3)
 integer :: n,ip,jp,kp, n_particles
+real(dp), allocatable :: rho_priv(:,:,:)
 
 if (present(resize_mesh)) then
     resize = resize_mesh
@@ -190,8 +192,15 @@ shrink_factor = 0
 if (present(mesh_shrink_factor)) shrink_factor = mesh_shrink_factor
 
 if (resize) then
-  min = [minval(xa), minval(ya), minval(za)]
-  max = [maxval(xa), maxval(ya), maxval(za)]
+  ! Fused min/max: single pass over all coordinate arrays instead of 6 separate minval/maxval calls.
+  min(1) = xa(1); max(1) = xa(1)
+  min(2) = ya(1); max(2) = ya(1)
+  min(3) = za(1); max(3) = za(1)
+  do n = 2, size(xa)
+    if (xa(n) < min(1)) then; min(1) = xa(n); else if (xa(n) > max(1)) then; max(1) = xa(n); endif
+    if (ya(n) < min(2)) then; min(2) = ya(n); else if (ya(n) > max(2)) then; max(2) = ya(n); endif
+    if (za(n) < min(3)) then; min(3) = za(n); else if (za(n) > max(3)) then; max(3) = za(n); endif
+  enddo
 
   if (growth_factor == 0 .and. shrink_factor == 0) then
     ! Original tight-fit behavior: compute delta, add tiny relative padding.
@@ -305,35 +314,84 @@ endif
 ! Clear 
 mesh3d%rho(ilo:ihi,jlo:jhi,klo:khi) = 0
 
-do n=1, n_particles
-  !if(lostflag(n).ne.0.d0)cycle
-  ip=floor((xa(n)-xmin)*dxi+1) !this is 1-based; use ilogbl for the general case
-  jp=floor((ya(n)-ymin)*dyi+1)
-  kp=floor((za(n)-zmin)*dzi+1)
-  ab=((xmin-xa(n))+ip*dx)*dxi
-  de=((ymin-ya(n))+jp*dy)*dyi
-  gh=((zmin-za(n))+kp*dz)*dzi
-! this "if" statement slows things down, but I'm using it for debugging purposes
+! Deposit particles onto mesh using trilinear weighting.
+if (n_particles >= 50000) then
+  ! OpenMP path: each thread accumulates into a private rho copy, then sum into shared mesh.
+  !$OMP PARALLEL PRIVATE(rho_priv, n, ip, jp, kp, ab, de, gh, oab, charge1) &
+  !$OMP& SHARED(mesh3d, xa, ya, za, qa, n_particles, dxi, dyi, dzi, dx, dy, dz, xmin, ymin, zmin, ilo, ihi, jlo, jhi, klo, khi)
+  allocate(rho_priv(ilo:ihi+1, jlo:jhi+1, klo:khi+1))
+  rho_priv = 0
 
-!  if(ip<ilo .or. jp<jlo .or. kp<klo .or. ip>ihi .or. jp>jhi .or. kp>khi)then
-!    ifail=ifail+1
-!    cycle
-!  else
+  if (present(qa)) then
+    !$OMP DO SCHEDULE(STATIC)
+    do n = 1, n_particles
+      ip = floor((xa(n)-xmin)*dxi+1)
+      jp = floor((ya(n)-ymin)*dyi+1)
+      kp = floor((za(n)-zmin)*dzi+1)
+      ab = ((xmin-xa(n))+ip*dx)*dxi
+      de = ((ymin-ya(n))+jp*dy)*dyi
+      gh = ((zmin-za(n))+kp*dz)*dzi
+      oab = 1.0_dp - ab
+      charge1 = qa(n)
+      rho_priv(ip,  jp,  kp)   = rho_priv(ip,  jp,  kp)   + ab *de     *gh     *charge1
+      rho_priv(ip,  jp+1,kp)   = rho_priv(ip,  jp+1,kp)   + ab *(1-de) *gh     *charge1
+      rho_priv(ip,  jp+1,kp+1) = rho_priv(ip,  jp+1,kp+1) + ab *(1-de) *(1-gh) *charge1
+      rho_priv(ip,  jp,  kp+1) = rho_priv(ip,  jp,  kp+1) + ab *de     *(1-gh) *charge1
+      rho_priv(ip+1,jp,  kp+1) = rho_priv(ip+1,jp,  kp+1) + oab*de     *(1-gh) *charge1
+      rho_priv(ip+1,jp+1,kp+1) = rho_priv(ip+1,jp+1,kp+1) + oab*(1-de) *(1-gh) *charge1
+      rho_priv(ip+1,jp+1,kp)   = rho_priv(ip+1,jp+1,kp)   + oab*(1-de) *gh     *charge1
+      rho_priv(ip+1,jp,  kp)   = rho_priv(ip+1,jp,  kp)   + oab*de     *gh     *charge1
+    enddo
+    !$OMP END DO
+  else
+    !$OMP DO SCHEDULE(STATIC)
+    do n = 1, n_particles
+      ip = floor((xa(n)-xmin)*dxi+1)
+      jp = floor((ya(n)-ymin)*dyi+1)
+      kp = floor((za(n)-zmin)*dzi+1)
+      ab = ((xmin-xa(n))+ip*dx)*dxi
+      de = ((ymin-ya(n))+jp*dy)*dyi
+      gh = ((zmin-za(n))+kp*dz)*dzi
+      oab = 1.0_dp - ab
+      rho_priv(ip,  jp,  kp)   = rho_priv(ip,  jp,  kp)   + ab *de     *gh     *charge1
+      rho_priv(ip,  jp+1,kp)   = rho_priv(ip,  jp+1,kp)   + ab *(1-de) *gh     *charge1
+      rho_priv(ip,  jp+1,kp+1) = rho_priv(ip,  jp+1,kp+1) + ab *(1-de) *(1-gh) *charge1
+      rho_priv(ip,  jp,  kp+1) = rho_priv(ip,  jp,  kp+1) + ab *de     *(1-gh) *charge1
+      rho_priv(ip+1,jp,  kp+1) = rho_priv(ip+1,jp,  kp+1) + oab*de     *(1-gh) *charge1
+      rho_priv(ip+1,jp+1,kp+1) = rho_priv(ip+1,jp+1,kp+1) + oab*(1-de) *(1-gh) *charge1
+      rho_priv(ip+1,jp+1,kp)   = rho_priv(ip+1,jp+1,kp)   + oab*(1-de) *gh     *charge1
+      rho_priv(ip+1,jp,  kp)   = rho_priv(ip+1,jp,  kp)   + oab*de     *gh     *charge1
+    enddo
+    !$OMP END DO
+  endif
 
-  if (present(qa)) charge1 = qa(n)
+  !$OMP CRITICAL (deposit_rho_reduce)
+  mesh3d%rho(ilo:ihi,jlo:jhi,klo:khi) = mesh3d%rho(ilo:ihi,jlo:jhi,klo:khi) + rho_priv(ilo:ihi,jlo:jhi,klo:khi)
+  !$OMP END CRITICAL (deposit_rho_reduce)
+  deallocate(rho_priv)
+  !$OMP END PARALLEL
 
-  mesh3d%rho(ip,jp,kp)=mesh3d%rho(ip,jp,kp)+ab*de*gh*charge1
-  mesh3d%rho(ip,jp+1,kp)=mesh3d%rho(ip,jp+1,kp)+ab*(1.-de)*gh*charge1
-  mesh3d%rho(ip,jp+1,kp+1)=mesh3d%rho(ip,jp+1,kp+1)+ab*(1.-de)*(1.-gh)*charge1
-  mesh3d%rho(ip,jp,kp+1)=mesh3d%rho(ip,jp,kp+1)+ab*de*(1.-gh)*charge1
-  mesh3d%rho(ip+1,jp,kp+1)=mesh3d%rho(ip+1,jp,kp+1)+(1.-ab)*de*(1.-gh)*charge1
-  mesh3d%rho(ip+1,jp+1,kp+1)=mesh3d%rho(ip+1,jp+1,kp+1)+(1.-ab)*(1.-de)*(1.-gh)*charge1
-  mesh3d%rho(ip+1,jp+1,kp)=mesh3d%rho(ip+1,jp+1,kp)+(1.-ab)*(1.-de)*gh*charge1
-  mesh3d%rho(ip+1,jp,kp)=mesh3d%rho(ip+1,jp,kp)+(1.-ab)*de*gh*charge1
-!  endif
-enddo
-
-!if(ifail.ne.0)write(6,*)'(depose_rho_scalar) ifail=',ifail
+else
+  ! Serial path for small particle counts (avoids OpenMP overhead)
+  do n = 1, n_particles
+    ip = floor((xa(n)-xmin)*dxi+1)
+    jp = floor((ya(n)-ymin)*dyi+1)
+    kp = floor((za(n)-zmin)*dzi+1)
+    ab = ((xmin-xa(n))+ip*dx)*dxi
+    de = ((ymin-ya(n))+jp*dy)*dyi
+    gh = ((zmin-za(n))+kp*dz)*dzi
+    oab = 1.0_dp - ab
+    if (present(qa)) charge1 = qa(n)
+    mesh3d%rho(ip,  jp,  kp)   = mesh3d%rho(ip,  jp,  kp)   + ab *de     *gh     *charge1
+    mesh3d%rho(ip,  jp+1,kp)   = mesh3d%rho(ip,  jp+1,kp)   + ab *(1-de) *gh     *charge1
+    mesh3d%rho(ip,  jp+1,kp+1) = mesh3d%rho(ip,  jp+1,kp+1) + ab *(1-de) *(1-gh) *charge1
+    mesh3d%rho(ip,  jp,  kp+1) = mesh3d%rho(ip,  jp,  kp+1) + ab *de     *(1-gh) *charge1
+    mesh3d%rho(ip+1,jp,  kp+1) = mesh3d%rho(ip+1,jp,  kp+1) + oab*de     *(1-gh) *charge1
+    mesh3d%rho(ip+1,jp+1,kp+1) = mesh3d%rho(ip+1,jp+1,kp+1) + oab*(1-de) *(1-gh) *charge1
+    mesh3d%rho(ip+1,jp+1,kp)   = mesh3d%rho(ip+1,jp+1,kp)   + oab*(1-de) *gh     *charge1
+    mesh3d%rho(ip+1,jp,  kp)   = mesh3d%rho(ip+1,jp,  kp)   + oab*de     *gh     *charge1
+  enddo
+endif
 
 
 end subroutine deposit_particles
@@ -439,6 +497,101 @@ if (present(B)) then
 endif
 
 end subroutine
+
+
+!------------------------------------------------------------------------
+!------------------------------------------------------------------------
+!------------------------------------------------------------------------
+!+
+! Subroutine interpolate_field_batch(x, y, z, mesh3d, n_pts, E, B)
+!
+! Vectorized batch interpolation of fields at multiple points.
+! OpenMP parallelized over the particle dimension.
+!
+! Input:
+!   x(n_pts), y(n_pts), z(n_pts) -- REAL64: coordinate arrays
+!   mesh3d                        -- mesh3d_struct: contains efield, bfield
+!   n_pts                         -- integer: number of points to interpolate
+!
+! Output:
+!   E(3,n_pts) -- REAL64, optional: interpolated electric field
+!   B(3,n_pts) -- REAL64, optional: interpolated magnetic field
+!-
+subroutine interpolate_field_batch(x, y, z, mesh3d, n_pts, E, B)
+type(mesh3d_struct), intent(in) :: mesh3d
+integer, intent(in) :: n_pts
+real(dp), intent(in) :: x(n_pts), y(n_pts), z(n_pts)
+real(dp), optional, intent(out) :: E(3, n_pts), B(3, n_pts)
+
+real(dp) :: hxi, hyi, hzi, ab, de, gh, oab, ode, ogh
+real(dp) :: w000, w010, w011, w001, w101, w111, w110, w100
+integer :: n, ip, jp, kp, ip1, jp1, kp1
+
+hxi = 1.0_dp / mesh3d%delta(1)
+hyi = 1.0_dp / mesh3d%delta(2)
+hzi = 1.0_dp / mesh3d%delta(3)
+
+!$OMP PARALLEL DO PRIVATE(n, ip, jp, kp, ip1, jp1, kp1, ab, de, gh, oab, ode, ogh, &
+!$OMP& w000, w010, w011, w001, w101, w111, w110, w100) &
+!$OMP& SHARED(mesh3d, x, y, z, E, B, n_pts, hxi, hyi, hzi) SCHEDULE(STATIC)
+do n = 1, n_pts
+  ip = floor((x(n) - mesh3d%min(1)) * hxi + 1)
+  jp = floor((y(n) - mesh3d%min(2)) * hyi + 1)
+  kp = floor((z(n) - mesh3d%min(3)) * hzi + 1)
+
+  ! Clamp to valid range
+  ip = max(1, min(ip, mesh3d%nhi(1) - 1))
+  jp = max(1, min(jp, mesh3d%nhi(2) - 1))
+  kp = max(1, min(kp, mesh3d%nhi(3) - 1))
+
+  ab  = ((mesh3d%min(1) - x(n)) + ip * mesh3d%delta(1)) * hxi
+  de  = ((mesh3d%min(2) - y(n)) + jp * mesh3d%delta(2)) * hyi
+  gh  = ((mesh3d%min(3) - z(n)) + kp * mesh3d%delta(3)) * hzi
+  oab = 1.0_dp - ab
+  ode = 1.0_dp - de
+  ogh = 1.0_dp - gh
+
+  ip1 = ip + 1; jp1 = jp + 1; kp1 = kp + 1
+
+  ! Precompute trilinear weights
+  w000 = ab  * de  * gh;   w010 = ab  * ode * gh
+  w011 = ab  * ode * ogh;  w001 = ab  * de  * ogh
+  w101 = oab * de  * ogh;  w111 = oab * ode * ogh
+  w110 = oab * ode * gh;   w100 = oab * de  * gh
+
+  if (present(E)) then
+    E(1,n) = mesh3d%efield(ip,jp,kp,1)*w000 + mesh3d%efield(ip,jp1,kp,1)*w010 &
+           + mesh3d%efield(ip,jp1,kp1,1)*w011 + mesh3d%efield(ip,jp,kp1,1)*w001 &
+           + mesh3d%efield(ip1,jp,kp1,1)*w101 + mesh3d%efield(ip1,jp1,kp1,1)*w111 &
+           + mesh3d%efield(ip1,jp1,kp,1)*w110 + mesh3d%efield(ip1,jp,kp,1)*w100
+    E(2,n) = mesh3d%efield(ip,jp,kp,2)*w000 + mesh3d%efield(ip,jp1,kp,2)*w010 &
+           + mesh3d%efield(ip,jp1,kp1,2)*w011 + mesh3d%efield(ip,jp,kp1,2)*w001 &
+           + mesh3d%efield(ip1,jp,kp1,2)*w101 + mesh3d%efield(ip1,jp1,kp1,2)*w111 &
+           + mesh3d%efield(ip1,jp1,kp,2)*w110 + mesh3d%efield(ip1,jp,kp,2)*w100
+    E(3,n) = mesh3d%efield(ip,jp,kp,3)*w000 + mesh3d%efield(ip,jp1,kp,3)*w010 &
+           + mesh3d%efield(ip,jp1,kp1,3)*w011 + mesh3d%efield(ip,jp,kp1,3)*w001 &
+           + mesh3d%efield(ip1,jp,kp1,3)*w101 + mesh3d%efield(ip1,jp1,kp1,3)*w111 &
+           + mesh3d%efield(ip1,jp1,kp,3)*w110 + mesh3d%efield(ip1,jp,kp,3)*w100
+  endif
+
+  if (present(B)) then
+    B(1,n) = mesh3d%bfield(ip,jp,kp,1)*w000 + mesh3d%bfield(ip,jp1,kp,1)*w010 &
+           + mesh3d%bfield(ip,jp1,kp1,1)*w011 + mesh3d%bfield(ip,jp,kp1,1)*w001 &
+           + mesh3d%bfield(ip1,jp,kp1,1)*w101 + mesh3d%bfield(ip1,jp1,kp1,1)*w111 &
+           + mesh3d%bfield(ip1,jp1,kp,1)*w110 + mesh3d%bfield(ip1,jp,kp,1)*w100
+    B(2,n) = mesh3d%bfield(ip,jp,kp,2)*w000 + mesh3d%bfield(ip,jp1,kp,2)*w010 &
+           + mesh3d%bfield(ip,jp1,kp1,2)*w011 + mesh3d%bfield(ip,jp,kp1,2)*w001 &
+           + mesh3d%bfield(ip1,jp,kp1,2)*w101 + mesh3d%bfield(ip1,jp1,kp1,2)*w111 &
+           + mesh3d%bfield(ip1,jp1,kp,2)*w110 + mesh3d%bfield(ip1,jp,kp,2)*w100
+    B(3,n) = mesh3d%bfield(ip,jp,kp,3)*w000 + mesh3d%bfield(ip,jp1,kp,3)*w010 &
+           + mesh3d%bfield(ip,jp1,kp1,3)*w011 + mesh3d%bfield(ip,jp,kp1,3)*w001 &
+           + mesh3d%bfield(ip1,jp,kp1,3)*w101 + mesh3d%bfield(ip1,jp1,kp1,3)*w111 &
+           + mesh3d%bfield(ip1,jp1,kp,3)*w110 + mesh3d%bfield(ip1,jp,kp,3)*w100
+  endif
+enddo
+!$OMP END PARALLEL DO
+
+end subroutine interpolate_field_batch
 
 
 !------------------------------------------------------------------------
@@ -657,8 +810,11 @@ if (.not. cache_hit) then
 endif
 
 ! rho -> crho -> FFT(crho)
-crho = 0
-crho(1:nx, 1:ny, 1:nz) = rho ! Place in one octant
+! Zero only the padding region (octants beyond 1:nx, 1:ny, 1:nz), then fill the data octant.
+crho(1:nx, 1:ny, 1:nz) = rho
+crho(nx+1:nx2, :, :) = 0
+crho(1:nx, ny+1:ny2, :) = 0
+crho(1:nx, 1:ny, nz+1:nz2) = 0
 call ccfft3d(crho, crho, [1,1,1], nx2, ny2, nz2, 0) 
 
 ! Loop over phi, Ex, Ey, Ez

--- a/bmad/space_charge/space_charge_mod.f90
+++ b/bmad/space_charge/space_charge_mod.f90
@@ -104,7 +104,9 @@ endif
 
 ! Calculate space charge field
 mesh3d%gamma = 1/sqrt(1- beta**2)
-call deposit_particles (position(1:n)%r(1), position(1:n)%r(2), position(1:n)%r(3), mesh3d, qa=position(1:n)%charge)
+
+call deposit_particles (position(1:n)%r(1), position(1:n)%r(2), position(1:n)%r(3), mesh3d, qa=position(1:n)%charge, &
+  mesh_growth_factor=space_charge_com%mesh_growth_factor, mesh_shrink_factor=space_charge_com%mesh_shrink_factor)
 call space_charge_3d(mesh3d, at_cathode=include_image, calc_bfield=.true., image_efield=mesh3d_image%efield)
 
 ! Determine if cathode image field should be turned off

--- a/bmad/space_charge/space_charge_mod.f90
+++ b/bmad/space_charge/space_charge_mod.f90
@@ -43,10 +43,13 @@ type (mesh3d_struct) :: mesh3d, mesh3d_image
 type (bunch_params_struct), optional :: bunch_params
 type (floor_position_struct) pos, pos0
 
-integer :: n, n_alive, i, imin(1), k
+integer :: n, n_alive, i, imin(1), k, n_interp
 real(rp) :: beta, ratio, t_end, s_ave, w_mat_inv(3,3)
 real(rp) :: Evec(3), Bvec(3), Evec_image(3), sigma(3)
 logical :: include_image, err, bend_here
+! Arrays for batch interpolation
+real(rp), allocatable :: x_interp(:), y_interp(:), z_interp(:), E_batch(:,:), B_batch(:,:)
+integer, allocatable :: interp_idx(:)
 
 ! Initialize variables
 mesh3d%nhi = space_charge_com%space_charge_mesh_size
@@ -128,30 +131,49 @@ if (include_image) then
   if (ratio <= space_charge_com%cathode_strength_cutoff) include_image = .false.
 endif
 
-! Calculate field at particle locations
+! Calculate field at particle locations using batch interpolation
+
+! First pass: identify particles needing interpolation and build coordinate arrays
+allocate(x_interp(size(bunch%particle)), y_interp(size(bunch%particle)), z_interp(size(bunch%particle)))
+allocate(interp_idx(size(bunch%particle)))
+n_interp = 0
 
 do i = 1, size(bunch%particle)
   p => bunch%particle(i)
-  if (p%state == pre_born$ .and. p%t <= t_end) then  ! Particles to be emitted
-    call interpolate_field(p%vec(1), p%vec(3), p%s,  mesh3d, E=sc_field(i)%E, B=sc_field(i)%B)
-  else if (p%state /= alive$) then ! Lost particles
-    sc_field(i)%E = 0
-    sc_field(i)%B = 0
-  else  ! Living particles
+  if (p%state == pre_born$ .and. p%t <= t_end) then
+    n_interp = n_interp + 1
+    x_interp(n_interp) = p%vec(1); y_interp(n_interp) = p%vec(3); z_interp(n_interp) = p%s
+    interp_idx(n_interp) = i
+  else if (p%state /= alive$) then
+    sc_field(i)%E = 0; sc_field(i)%B = 0
+  else
     if (present(bunch_params)) then
-      if (out_of_sigma_cutoff(p)) then  ! Ignore particles too far off the bunch
-        sc_field(i)%E = 0
-        sc_field(i)%B = 0
+      if (out_of_sigma_cutoff(p)) then
+        sc_field(i)%E = 0; sc_field(i)%B = 0
+        cycle
       endif
     endif
-    call interpolate_field(p%vec(1), p%vec(3), p%s,  mesh3d, E=sc_field(i)%E, B=sc_field(i)%B)
-    if (bend_here .and. .false.) then
-      k = w(i)%ixp
-      sc_field(i)%E = matmul(w(k)%w_mat, sc_field(i)%E)
-      sc_field(i)%B = matmul(w(k)%w_mat, sc_field(i)%B)
-    endif
+    n_interp = n_interp + 1
+    x_interp(n_interp) = p%vec(1); y_interp(n_interp) = p%vec(3); z_interp(n_interp) = p%s
+    interp_idx(n_interp) = i
   end if
 enddo
+
+! Batch interpolation (OpenMP parallelized internally)
+if (n_interp > 0) then
+  allocate(E_batch(3, n_interp), B_batch(3, n_interp))
+  call interpolate_field_batch(x_interp, y_interp, z_interp, mesh3d, n_interp, E=E_batch, B=B_batch)
+
+  ! Scatter results back to sc_field
+  do k = 1, n_interp
+    i = interp_idx(k)
+    sc_field(i)%E = E_batch(:, k)
+    sc_field(i)%B = B_batch(:, k)
+  enddo
+  deallocate(E_batch, B_batch)
+endif
+
+deallocate(x_interp, y_interp, z_interp, interp_idx)
 
 !-------------------------------------------------------------------
 contains

--- a/regression_tests/space_charge_test/space_charge_test.f90
+++ b/regression_tests/space_charge_test/space_charge_test.f90
@@ -24,6 +24,10 @@ integer i
 
 open (1, file = 'output.now')
 
+! Disable lazy mesh resizing so regression results match the original tight-fit behavior.
+space_charge_com%mesh_growth_factor = 0
+space_charge_com%mesh_shrink_factor = 0
+
 ! bbi_kick test
 
 sigma = [10.0_rp, 10.0_rp]

--- a/tao/code/tao_pipe_cmd.f90
+++ b/tao/code/tao_pipe_cmd.f90
@@ -7118,6 +7118,8 @@ case ('space_charge_com')
   nl=incr(nl); write(li(nl), rmt)  'beam_chamber_height;REAL;T;',              space_charge_com%beam_chamber_height
   nl=incr(nl); write(li(nl), rmt)  'lsc_sigma_cutoff;REAL;T;',                 space_charge_com%lsc_sigma_cutoff
   nl=incr(nl); write(li(nl), rmt)  'particle_sigma_cutoff;REAL;T;',            space_charge_com%particle_sigma_cutoff
+  nl=incr(nl); write(li(nl), rmt)  'mesh_growth_factor;REAL;T;',               space_charge_com%mesh_growth_factor
+  nl=incr(nl); write(li(nl), rmt)  'mesh_shrink_factor;REAL;T;',               space_charge_com%mesh_shrink_factor
 
   nl=incr(nl); write(li(nl), iamt) 'space_charge_mesh_size;INT_ARR;T',         (';', space_charge_com%space_charge_mesh_size(j), j = 1, 3)
   nl=incr(nl); write(li(nl), iamt) 'csr3d_mesh_size;INT_ARR;T',                (';', space_charge_com%csr3d_mesh_size(j), j = 1, 3)

--- a/tao/code/tao_set_mod.f90
+++ b/tao/code/tao_set_mod.f90
@@ -682,7 +682,7 @@ case ('diagnostic_output_file')
   space_charge_com%diagnostic_output_file = unquote(value_str)
   return
 
-case ('ds_track_step', 'beam_chamber_height', 'sigma_cutoff')
+case ('ds_track_step', 'beam_chamber_height', 'sigma_cutoff', 'mesh_growth_factor', 'mesh_shrink_factor')
   call tao_evaluate_expression (value_str, 1, .false., set_val, err); if (err) return
   write (val, '(es24.16)', iostat = ios) set_val(1)
 

--- a/tao/code/tao_show_this.f90
+++ b/tao/code/tao_show_this.f90
@@ -560,6 +560,8 @@ case ('beam')
     nl=nl+1; write(lines(nl), rmt) '  %beam_chamber_height            = ', space_charge_com%beam_chamber_height
     nl=nl+1; write(lines(nl), rmt) '  %lsc_sigma_cutoff               = ', space_charge_com%lsc_sigma_cutoff
     nl=nl+1; write(lines(nl), rmt) '  %particle_sigma_cutoff          = ', space_charge_com%particle_sigma_cutoff
+    nl=nl+1; write(lines(nl), rmt) '  %mesh_growth_factor             = ', space_charge_com%mesh_growth_factor
+    nl=nl+1; write(lines(nl), rmt) '  %mesh_shrink_factor             = ', space_charge_com%mesh_shrink_factor
     nl=nl+1; write(lines(nl), imt) '  %space_charge_mesh_size         = ', space_charge_com%space_charge_mesh_size
     nl=nl+1; write(lines(nl), imt) '  %csr3d_mesh_size                = ', space_charge_com%csr3d_mesh_size
     nl=nl+1; write(lines(nl), imt) '  %n_bin                          = ', space_charge_com%n_bin
@@ -2306,6 +2308,8 @@ case ('global')
     nl=nl+1; write(lines(nl), rmt) '  %beam_chamber_height            = ', space_charge_com%beam_chamber_height
     nl=nl+1; write(lines(nl), rmt) '  %lsc_sigma_cutoff               = ', space_charge_com%lsc_sigma_cutoff
     nl=nl+1; write(lines(nl), rmt) '  %particle_sigma_cutoff          = ', space_charge_com%particle_sigma_cutoff
+    nl=nl+1; write(lines(nl), rmt) '  %mesh_growth_factor             = ', space_charge_com%mesh_growth_factor
+    nl=nl+1; write(lines(nl), rmt) '  %mesh_shrink_factor             = ', space_charge_com%mesh_shrink_factor
     nl=nl+1; write(lines(nl), imt) '  %space_charge_mesh_size         = ', space_charge_com%space_charge_mesh_size
     nl=nl+1; write(lines(nl), imt) '  %csr3d_mesh_size                = ', space_charge_com%csr3d_mesh_size
     nl=nl+1; write(lines(nl), imt) '  %n_bin                          = ', space_charge_com%n_bin


### PR DESCRIPTION
## Optimize FFT-based space charge calculation

### Summary

Reduces wall-clock time of the FFT-based 3D space charge calculation by **~5x** at 10K particles and **~2.7x** at 100K particles on the `bmad-doc/tao_examples/space_charge` test case (32×32×64 mesh). Results are physically equivalent to the baseline.

### Changes

**`bmad/space_charge/fft_interface_mod.f90`**

- **Cache FFTW plans**: Previously, every call to `ccfft3d` created a new FFTW plan with `FFTW_ESTIMATE`, executed it, and destroyed it. With ~7 FFTs per field solve and ~3 field solves per adaptive step, this was ~21 plan create/destroy cycles per time step. Now, forward and backward plans are cached as `save` variables and only rebuilt when the mesh dimensions change (which almost never happens during a run).

- **Use `FFTW_MEASURE` instead of `FFTW_ESTIMATE`**: `FFTW_MEASURE` runs a brief benchmark on first plan creation to find the optimal FFT algorithm. This adds a one-time cost of ~0.5s but gives faster execution on every subsequent FFT.

- **One-time OpenMP thread setup**: `fftw_plan_with_nthreads` and `fftw_cleanup_threads` were being called on every `ccfft3d` invocation. Now the thread count is set once at initialization via `fft_cache_init()`.

**`bmad/space_charge/open_spacecharge_mod.f90`**

- **Persistent scratch arrays**: The `crho` and `cgrn` complex scratch arrays in `osc_freespace_solver2` (each 2N×2N×2N complex doubles, ~8 MB for the default mesh) were allocated and deallocated on every call. Now they are `save` variables that persist across calls and are only reallocated when the mesh size changes.

- **Lazy mesh resizing**: `deposit_particles` now keeps the mesh bounds stable across calls, only resizing when the bunch grows beyond the mesh or shrinks significantly (controlled by `mesh_growth_factor` and `mesh_shrink_factor`). When both factors are 0, the original tight-fit behavior is restored exactly. This keeps `delta` constant, enabling the Green function FFT cache below.

- **Green function FFT cache**: `osc_freespace_solver2` caches the forward-FFT of the Green function, keyed by `(delta, gamma, offset, mesh_size)`. The Green function depends only on grid geometry and relativistic gamma — not on the particle distribution — so it stays valid as long as the mesh doesn't resize. The charge density `rho` is freshly deposited from particle positions every step and FFT'd as usual. When the cache hits, the expensive Green function computation and its forward FFT are skipped entirely — only the rho FFT, pointwise multiply, and inverse FFT are needed.

- **Fused min/max computation**: `deposit_particles` now computes all 6 coordinate extrema (min/max of x, y, z) in a single pass over the particle arrays, replacing 6 separate `minval`/`maxval` calls.

- **OpenMP parallel deposition**: For large bunches (≥ 50K particles), `deposit_particles` uses thread-private rho arrays with a critical-section reduction. Below the threshold, the serial loop is used to avoid OpenMP overhead.

- **Batch field interpolation**: New `interpolate_field_batch` subroutine performs trilinear interpolation for an array of points with explicit scalar weights per field component (avoiding the `(:)` array-section overhead of the original). Includes `!$OMP PARALLEL DO` over the particle dimension. Bounds are clamped rather than checked with per-particle I/O.

- **Reduced crho zeroing**: `osc_freespace_solver2` now zeros only the padding region of the doubled complex array (the 7 octants outside `1:nx, 1:ny, 1:nz`), since the data octant is immediately overwritten by the rho copy. Saves 7/8 of a ~32 MB memset per call.

**`bmad/modules/bmad_struct.f90`**

- Added `mesh_growth_factor` (default 0.1) and `mesh_shrink_factor` (default 0.1) fields to `space_charge_common_struct`, so users can tune the lazy resize behavior via `set space_charge_com mesh_growth_factor = <value>`.

**`tao/code/tao_set_mod.f90`**

- Added `mesh_growth_factor` and `mesh_shrink_factor` to the Tao `set space_charge_com` handler.

**`tao/code/tao_show_this.f90`**

- Added `mesh_growth_factor` and `mesh_shrink_factor` to the `show global` and `show global -space_charge_com` output.

**`tao/code/tao_pipe_cmd.f90`**

- Added `mesh_growth_factor` and `mesh_shrink_factor` to the `pipe space_charge_com` output.

**`bmad/space_charge/space_charge_mod.f90`**

- `sc_field_calc` passes `space_charge_com%mesh_growth_factor` and `%mesh_shrink_factor` as optional arguments to `deposit_particles`.
- Field interpolation loop replaced with batch `interpolate_field_batch` call: coordinates are gathered, batch-interpolated (OpenMP parallelized), then results scattered back.

**`bmad/space_charge/csr_and_space_charge_mod.f90`**

- Both `deposit_particles` call sites in the `fft_3d$` path pass `space_charge_com%mesh_growth_factor` and `%mesh_shrink_factor`.
- **Extracted `apply_fft_3d_kicks`**: The `fft_3d$` space charge block (deposit, solve, interpolate, kick) is now a standalone subroutine, called from `csr_and_sc_apply_kicks`. Uses `interpolate_field_batch` for the interpolation phase, then applies kicks in a separate loop.
- **OpenMP parallel kick application**: The kick loop after field interpolation is parallelized with `!$OMP PARALLEL DO`. Each particle's kick is independent, so this scales with core count. Saves ~5s at 1M particles.

**`regression_tests/space_charge_test/space_charge_test.f90`**

- Sets `mesh_growth_factor = 0` and `mesh_shrink_factor = 0` at the start of the test to use the original tight-fit mesh behavior, ensuring bit-level reproducibility with the existing `output.correct`.

**Thread safety**: All module-level state mutations are guarded with `!$OMP CRITICAL` sections. Currently these routines are only called from serial code, but the guards protect against future use from parallel regions. FFTW plan creation/destruction and `fftw_plan_with_nthreads` are not thread-safe per FFTW documentation.

### Benchmark

Test: `cd bmad-doc/tao_examples/space_charge && tao -noplot -command "set beam_init n_particle = N;set space_charge_com ds_track_step = 0.001;quit"`
(32×32×64 mesh, 1m pipe, `fft_3d` space charge, adaptive time stepping)

| N particles | Before | After | Speedup |
|---|---|---|---|
| 10,000 | 31s | **6s** | **5.2x** |
| 100,000 | 41s | **11s** | **3.7x** |
| 1,000,000 | 155s | **64s** | **2.4x** |

`show beam end` output is physically equivalent before and after (emittance within ~0.04%).

# Perlmutter (NERSC) testing

[This is a similar benchmark](https://gist.github.com/ChristopherMayes/b694bec60363ccf22c38080a5e632a53) and relative speedup comparison for various numbers of threads on Perlmutter. 

<img width="960" height="720" alt="bmad_pr_1977_perlmutter_speedup" src="https://github.com/user-attachments/assets/174e81d3-6895-4112-8542-051c4b4dfff5" />
