### PR TITLE
Fix test suite to address PyTao v1 changes

### DIFF
--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -28,6 +28,12 @@ runs:
       run: |
         conda list
 
+    - name: Install PyTao
+      shell: bash -l {0}
+      run: |
+        cd pytao
+        python -m pip install --no-deps .
+
     - name: Ensure importability
       shell: bash -l {0}
       run: |

--- a/.github/workflows/pytao.yml
+++ b/.github/workflows/pytao.yml
@@ -50,9 +50,9 @@ jobs:
 
       - name: Regenerate Tao interface commands
         shell: bash -l {0}
-        working-directory: ./pytao
+        working-directory: ./pytao/scripts
         run: |
-          bash scripts/bump_minimum_version.sh
+          python generate_interface_commands.py
 
       - name: Reformat the generated source code
         shell: bash -l {0}

--- a/.github/workflows/pytao.yml
+++ b/.github/workflows/pytao.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: ./.github/actions/conda-setup
         with:
           python-version: ${{ matrix.python-version }}
-          environment-file: pytao/dev-environment.yml
+          environment-file: pytao/environment.yml
 
       - name: Setup ACC_ROOT_DIR
         shell: bash -l {0}

--- a/.github/workflows/pytao.yml
+++ b/.github/workflows/pytao.yml
@@ -54,6 +54,12 @@ jobs:
         run: |
           python generate_interface_commands.py
 
+      - name: Reinstall PyTao with updated interface commands
+        shell: bash -l {0}
+        working-directory: ./pytao
+        run: |
+          python -m pip install --no-deps .
+
       - name: Reformat the generated source code
         shell: bash -l {0}
         working-directory: ./pytao

--- a/regression_tests/pytao/expressions/test_expressions.py
+++ b/regression_tests/pytao/expressions/test_expressions.py
@@ -22,7 +22,9 @@ basic_arithmetic_tests = [
     pytest.param("20 / 4", 5, id="20 / 4"),
     pytest.param("2^3", 8, id="2^3"),
     pytest.param("-5", -5, id="-5"),
-    pytest.param("--5", 5, id="--5"),
+    pytest.param(
+        "--5", 5, id="--5", marks=pytest.mark.xfail(reason="--5 doesn't parse")
+    ),
 ]
 
 rounding_tests = [
@@ -99,7 +101,7 @@ reduction_function_tests = [
     pytest.param("min([1, 2, 3, 4, 5])", 1, id="min"),
     pytest.param("max([1, 2, 3, 4, 5])", 5, id="max"),
     pytest.param("sum([1, 2, 3, 4, 5])", 15, id="sum"),
-    pytest.param("mean([1, 2, 3, 4, 5])", 3, id="mean"),
+    # pytest.param("mean([1, 2, 3, 4, 5])", 3, id="mean"), # -> average
     pytest.param("average([1, 2, 3, 4, 5])", 3, id="average"),
     pytest.param("rms([1, 2, 3, 4, 5])", rms([1, 2, 3, 4, 5]), id="rms"),
 ]
@@ -165,8 +167,9 @@ def test_ran(tao: Tao) -> None:
     assert 0 <= val <= 1
 
 
-def test_species_of(tao: Tao) -> None:
-    tao.evaluate("species_of(C)")  # ?
+# def test_species_of(tao: Tao) -> None:
+#     # Not really a thing
+#     tao.evaluate("species_of(C)")  # ?
 
 
 @pytest.mark.parametrize(

--- a/regression_tests/pytao/sr_wakes/test_sr_wakes.py
+++ b/regression_tests/pytao/sr_wakes/test_sr_wakes.py
@@ -47,17 +47,15 @@ def assert_dicts_allclose(d1, d2, rtol=1e-5, atol=1e-8):
 
 def test_sr_wakes_onoff():
     lattice_root = Path(__file__).parent.resolve()
-    lattice_file = lattice_root / "lat.bmad"
-    startup_file = lattice_root / "tao.startup"
 
     prev = os.getcwd()
     try:
         os.chdir(lattice_root)
         with SubprocessTao(
-            lattice_file=lattice_file,
-            startup_file=startup_file,
-            noplot=True,
+            lattice_file="lat.bmad", startup_file="tao.startup", noplot=True
         ) as tao:
+            print("Init output:")
+            print("\n".join(tao.init_output))
             tao.cmd("set bmad sr_wakes_on = F")
             d1 = tao.bunch_data("end")
 

--- a/regression_tests/pytao/sr_wakes/test_sr_wakes.py
+++ b/regression_tests/pytao/sr_wakes/test_sr_wakes.py
@@ -1,6 +1,9 @@
+import os
 from pathlib import Path
+
 import numpy as np
-from pytao import Tao
+from pytao import SubprocessTao
+
 
 def assert_dicts_allclose(d1, d2, rtol=1e-5, atol=1e-8):
     """
@@ -23,31 +26,46 @@ def assert_dicts_allclose(d1, d2, rtol=1e-5, atol=1e-8):
         If any entry mismatches or types differ.
     """
     assert d1.keys() == d2.keys(), f"Keys differ: {d1.keys()} vs {d2.keys()}"
-    
+
     for key in d1:
         v1 = d1[key]
         v2 = d2[key]
-        
+
         if isinstance(v1, np.ndarray):
-            assert isinstance(v2, np.ndarray), f"Type mismatch for key '{key}': ndarray vs {type(v2)}"
-            assert v1.shape == v2.shape, f"Shape mismatch for key '{key}': {v1.shape} vs {v2.shape}"
-            assert np.allclose(v1, v2, rtol=rtol, atol=atol), f"Array values differ for key '{key}'"
+            assert isinstance(
+                v2, np.ndarray
+            ), f"Type mismatch for key '{key}': ndarray vs {type(v2)}"
+            assert (
+                v1.shape == v2.shape
+            ), f"Shape mismatch for key '{key}': {v1.shape} vs {v2.shape}"
+            assert np.allclose(
+                v1, v2, rtol=rtol, atol=atol
+            ), f"Array values differ for key '{key}'"
         else:
             assert v1 == v2, f"Scalar values differ for key '{key}': {v1} vs {v2}"
 
 
-
 def test_sr_wakes_onoff():
-    lattice_file = Path(__file__).parent / "lat.bmad"
-    startup_file = Path(__file__).parent / "tao.startup"
+    lattice_root = Path(__file__).parent.resolve()
+    lattice_file = lattice_root / "lat.bmad"
+    startup_file = lattice_root / "tao.startup"
 
-    
-    tao = Tao(lattice_file=lattice_file, startup_file=startup_file, noplot=True)
-   
-    tao.cmd('set bmad sr_wakes_on = F')
-    d1 = tao.bunch_data('end')
-    
-    tao.cmd('set bmad sr_wakes_on = T')
-    d2 = tao.bunch_data('end')
+    prev = os.getcwd()
+    try:
+        os.chdir(lattice_root)
+        with SubprocessTao(
+            lattice_file=lattice_file,
+            startup_file=startup_file,
+            noplot=True,
+        ) as tao:
+            tao.cmd("set bmad sr_wakes_on = F")
+            d1 = tao.bunch_data("end")
+
+            tao.cmd("set bmad sr_wakes_on = T")
+            d2 = tao.bunch_data("end")
+    finally:
+        os.chdir(prev)
+
+    assert len(d1)
 
     assert_dicts_allclose(d1, d2)


### PR DESCRIPTION
PyTao 1.0 now handles error reporting more consistently, meaning some issues in the regression test suite were silently getting ignored. This PR intends to resolve those.

1. Expressions
   * `--5` does not parse as an expression. I think it should and would consider this a (low priority) bug. (note this one @DavidSagan ). I marked this as `xfail` (or expected fail) so it can be addressed at a later date.
   * `mean([...])` appears to be something I hallucinated (oops; removed - even humans can hallucinate I suppose)
   * `species_of(C)` returned some integer before along with an error, but this is not really useful so I removed it
1. `regression_tests/pytao/sr_wakes/test_sr_wakes.py` was not functional
   * It was failing to load `particles3.h5` due to it searching the current working directory for the particle file rather than where the lattice file is. The test had previously passed as the empty bunch params dict was equivalent to the second empty one.
   * I addressed this with `SubprocessTao` and changing the working directory prior to running it (which gives me an idea that `SubprocessTao` should also just take a `cwd=` parameter...)
1. PyTao v1 removed `dev-environment.yml` and now just recommends `environment.yml` for all
1. PyTao now does more when rebuilding its files, digging into Bmad's structure source code. I'm disabling that part of the workflow and am hopeful it'll be enough to get CI going again here. Let's see...