### PR TITLE
Let Tao use `transfer_fieldmap`

### DIFF
--- a/bmad-doc/lattices/transfer_fieldmap_example/lat.bmad
+++ b/bmad-doc/lattices/transfer_fieldmap_example/lat.bmad
@@ -1,0 +1,44 @@
+! Minimal lattice demonstrating fieldmap transfer between elements.
+! sol_a has an inline grid_field; sol_b and sol_c are identical solenoids
+! whose fieldmap data will be shared from sol_a via the Tao command:
+!   set element sol_b fieldmap = sol_a
+!   set element sol_c fieldmap = sol_a
+
+no_digested
+
+parameter[geometry] = open
+parameter[p0c]      = 1e9
+parameter[particle] = electron
+
+beginning[beta_a] = 10
+beginning[beta_b] = 10
+
+d1: drift, l = 0.5
+
+sol_a: solenoid, l = 1,
+  tracking_method   = runge_kutta,
+  mat6_calc_method  = tracking,
+  field_calc        = fieldmap,
+  grid_field = {
+    geometry   = rotationally_symmetric_rz,
+    field_type = magnetic,
+    harmonic   = 0,
+    dr         = (0.01, 0.5),
+    r0         = (0, 0, -0.5),
+    pt(0,0) = (0, 0, 1e-4),
+    pt(0,1) = (0, 0, 1e-4),
+    pt(1,0) = (0, 0, 1e-4),
+    pt(1,1) = (0, 0, 1e-4)}
+
+sol_b: solenoid, l = 1,
+  tracking_method   = runge_kutta,
+  mat6_calc_method  = tracking,
+  field_calc        = fieldmap
+
+sol_c: solenoid, l = 1,
+  tracking_method   = runge_kutta,
+  mat6_calc_method  = tracking,
+  field_calc        = fieldmap
+
+lat: line = (sol_a, d1, sol_b, d1, sol_c)
+use, lat

--- a/bmad-doc/lattices/transfer_fieldmap_example/tao.init
+++ b/bmad-doc/lattices/transfer_fieldmap_example/tao.init
@@ -1,0 +1,15 @@
+&tao_start
+  startup_file = 'tao.startup'
+/
+
+&tao_design_lattice
+  n_universes = 1
+  design_lattice(1)%file = "lat.bmad"
+/
+
+&tao_params
+  global%track_type = 'single'
+  global%optimizer  = 'lmdif'
+  bmad_com%radiation_damping_on      = F
+  bmad_com%radiation_fluctuations_on = F
+/

--- a/bmad-doc/lattices/transfer_fieldmap_example/tao.startup
+++ b/bmad-doc/lattices/transfer_fieldmap_example/tao.startup
@@ -1,0 +1,10 @@
+! Show that sol_b has no grid_field before transfer
+show ele sol_b
+
+! Transfer fieldmap data from sol_a to sol_b and sol_c
+set element sol_b fieldmap = sol_a
+set element sol_c fieldmap = sol_a
+
+! Confirm sol_b and sol_c now have grid_field data
+show ele sol_b
+show ele sol_c

--- a/tao/code/tao_set_mod.f90
+++ b/tao/code/tao_set_mod.f90
@@ -3070,7 +3070,9 @@ if (upcase(attribute) == 'FIELDMAP') then
 
   do i = lbound(s%u, 1), ubound(s%u, 1)
     u => s%u(i)
-    if (.not. u%calc%lattice .or. .not. s%global%lattice_calc_on) cycle
+    u%calc%lattice = .true.
+    if (.not. s%global%lattice_calc_on) cycle
+    call set_flags_for_changed_attribute (u%model%lat)
     call lattice_bookkeeper (u%model%lat)
   enddo
 

--- a/tao/code/tao_set_mod.f90
+++ b/tao/code/tao_set_mod.f90
@@ -3052,6 +3052,31 @@ if (size(eles) == 0) then
   return
 endif
 
+! Special handling for "fieldmap" attribute: share fieldmap data from one element to another.
+! Syntax: set element <ele_out> fieldmap = <ele_in>
+
+if (upcase(attribute) == 'FIELDMAP') then
+  call tao_locate_all_elements (value, v_eles, err)
+  if (err) return
+  if (size(v_eles) /= 1) then
+    call out_io (s_error$, r_name, 'SOURCE ELEMENT FOR FIELDMAP TRANSFER MUST BE A SINGLE ELEMENT. ' // &
+                                   'NUMBER OF ELEMENTS MATCHED: ' // int_str(size(v_eles)))
+    return
+  endif
+
+  do i = 1, size(eles)
+    call transfer_fieldmap (v_eles(1)%ele, eles(i)%ele, all$)
+  enddo
+
+  do i = lbound(s%u, 1), ubound(s%u, 1)
+    u => s%u(i)
+    if (.not. u%calc%lattice .or. .not. s%global%lattice_calc_on) cycle
+    call lattice_bookkeeper (u%model%lat)
+  enddo
+
+  return
+endif
+
 !-----------
 ! The first complication is that what is being set can be a logical, switch (like an element's tracking_method), etc.
 ! So use set_ele_attribute to do the set.

--- a/tao/doc/command-list.tex
+++ b/tao/doc/command-list.tex
@@ -1365,14 +1365,20 @@ only the element in the viewed universe is used. See the examples below.
 Note: It is also possible to use the \vn{change element} command to change real (as opposed to
 logical or integer) attributes.
 
+The \vn{fieldmap} pseudo-attribute transfers all fieldmap data (grid fields, cartesian maps,
+cylindrical maps, and generalized gradient maps) from a source element to the target element(s)
+via pointer sharing. This avoids duplicating large field tables in memory when multiple elements
+use the same field data. The \vn{<value>} must resolve to a single source element.
+
 Examples:
 \begin{example}
   set ele rfcav::* is_on = F         ! Turn off all rfcavity elements the viewed universe.
   set ele *@rfcav::* is_on = F       ! Turn off all rfcavity elements in all universes.
-  set ele A:B track_method = linear  ! Set tracking_method for all elements between 
+  set ele A:B track_method = linear  ! Set tracking_method for all elements between
                                      !   elements A and B
   set ele q10w k1 = 0.7              ! Set element q10w k1 of the viewed universe.
   set ele Q* k1 = ele::Q*[k1]|design ! Set model to design values.
+  set ele sol_b fieldmap = sol_a     ! Share sol_a's fieldmap data with sol_b.
 \end{example}
 
 %% set floor_plan --------------------------------------------------------------


### PR DESCRIPTION
## Add `set element <ele> fieldmap = <source>` Tao command

Exposes Bmad's existing `transfer_fieldmap` through the Tao command interface. This lets users load a fieldmap once and share it to other elements via pointer sharing, rather than loading redundant copies from disk.

### Changes

- **`tao/code/tao_set_mod.f90`** -- Intercept `attribute == "FIELDMAP"` in `tao_set_elements_cmd`. Locates the source element, calls `transfer_fieldmap(..., all$)` for each target, then marks the lattice for recalculation.
- **`tao/doc/command-list.tex`** -- Document the new `fieldmap` pseudo-attribute in the `set element` section.
- **`bmad-doc/lattices/transfer_fieldmap_example/`** -- Minimal example: three solenoids, one with an inline grid_field, two receiving it via the new command.

### Usage

```
set element sol_b fieldmap = sol_a          ! single element
set element solenoid::* fieldmap = sol_a    ! wildcard
```

Closes #1997 