### PR TITLE
FIX: dangling file reference in read_beam_ascii

### DIFF
--- a/bmad/multiparticle/beam_file_io.f90
+++ b/bmad/multiparticle/beam_file_io.f90
@@ -887,7 +887,7 @@ do
     if (ios /= 0) then
       call out_io (s_error$, r_name, 'CANNOT READ BUNCH HEADER IN FILE: ' // file_name, &
                                      'LINE NUMBER ' // int_str(n_line))
-      return
+      goto 9000
     endif
 
     if (line == '') cycle
@@ -907,43 +907,43 @@ do
       call out_io (s_error$, r_name, 'FIRST CHARACTER IN HEADER LINE NOT A "#" CHARACTER: ' // quote(line(1:20)) // '...', &
                                      'IN FILE: ' // file_name, & 
                                      'LINE NUMBER ' // int_str(n_line))
-      return
+      goto 9000
     endif
 
     if (index(line, '=') == 0) cycle
     call string_trim(line(2:), line, ix)
 
     select case (downcase(line(:ix)))
-    case ('charge_tot');  bunch%charge_tot = read_param(line, n_line, err); if (err) return
+    case ('charge_tot');  bunch%charge_tot = read_param(line, n_line, err); if (err) goto 9000
 
     case ('location')
-      str = read_string(line, n_line, err); if (err) return
-      call read_switch(line(:ix), p0%location, str, n_line, err); if (err) return
+      str = read_string(line, n_line, err); if (err) goto 9000
+      call read_switch(line(:ix), p0%location, str, n_line, err); if (err) goto 9000
 
     case ('state')
-      str = unquote(read_string(line, n_line, err)); if (err) return
-      call read_switch(line(:ix), p0%state, str, n_line, err); if (err) return
+      str = unquote(read_string(line, n_line, err)); if (err) goto 9000
+      call read_switch(line(:ix), p0%state, str, n_line, err); if (err) goto 9000
 
     case ('species')
-      str = unquote(read_string(line, n_line, err)); if (err) return
-      call read_switch(line(:ix), p0%species, str, n_line, err); if (err) return
+      str = unquote(read_string(line, n_line, err)); if (err) goto 9000
+      call read_switch(line(:ix), p0%species, str, n_line, err); if (err) goto 9000
 
-    case ('r');                p0%r           = read_param(line, n_line, err); if (err) return
-    case ('s', 's_position');  p0%s           = read_param(line, n_line, err); if (err) return
-    case ('t', 'time');        p0%t           = read_param(line, n_line, err); if (err) return
-    case ('p0c');              p0%p0c         = read_param(line, n_line, err); if (err) return
-    case ('charge');           p0%charge      = read_param(line, n_line, err); if (err) return
-    case ('dt_ref');           p0%dt_ref      = read_param(line, n_line, err); if (err) return
-    case ('e_potential');      p0%E_potential = read_param(line, n_line, err); if (err) return
-    case ('beta');             p0%beta        = read_param(line, n_line, err); if (err) return; beta_found = .true.
-    case ('spin');             call read_params(line, n_line, p0%spin, err); if (err) return
-    case ('field');            call read_params(line, n_line, p0%field, err); if (err) return
-    case ('phase');            call read_params(line, n_line, p0%phase, err); if (err) return
-    case ('time_dir');         p0%time_dir    = nint(read_param(line, n_line, err)); if (err) return
-    case ('direction');        p0%direction   = nint(read_param(line, n_line, err)); if (err) return
-    case ('ix_ele');           p0%ix_ele      = nint(read_param(line, n_line, err)); if (err) return
-    case ('ix_branch');        p0%ix_branch   = nint(read_param(line, n_line, err)); if (err) return
-    case ('ix_user');          p0%ix_user     = nint(read_param(line, n_line, err)); if (err) return
+    case ('r');                p0%r           = read_param(line, n_line, err); if (err) goto 9000
+    case ('s', 's_position');  p0%s           = read_param(line, n_line, err); if (err) goto 9000
+    case ('t', 'time');        p0%t           = read_param(line, n_line, err); if (err) goto 9000
+    case ('p0c');              p0%p0c         = read_param(line, n_line, err); if (err) goto 9000
+    case ('charge');           p0%charge      = read_param(line, n_line, err); if (err) goto 9000
+    case ('dt_ref');           p0%dt_ref      = read_param(line, n_line, err); if (err) goto 9000
+    case ('e_potential');      p0%E_potential = read_param(line, n_line, err); if (err) goto 9000
+    case ('beta');             p0%beta        = read_param(line, n_line, err); if (err) goto 9000; beta_found = .true.
+    case ('spin');             call read_params(line, n_line, p0%spin, err); if (err) goto 9000
+    case ('field');            call read_params(line, n_line, p0%field, err); if (err) goto 9000
+    case ('phase');            call read_params(line, n_line, p0%phase, err); if (err) goto 9000
+    case ('time_dir');         p0%time_dir    = nint(read_param(line, n_line, err)); if (err) goto 9000
+    case ('direction');        p0%direction   = nint(read_param(line, n_line, err)); if (err) goto 9000
+    case ('ix_ele');           p0%ix_ele      = nint(read_param(line, n_line, err)); if (err) goto 9000
+    case ('ix_branch');        p0%ix_branch   = nint(read_param(line, n_line, err)); if (err) goto 9000
+    case ('ix_user');          p0%ix_user     = nint(read_param(line, n_line, err)); if (err) goto 9000
     end select
   enddo header_loop
 
@@ -955,7 +955,7 @@ do
     n_line = n_line + 1
     if (ios /= 0) then
       call out_io (s_error$, r_name, 'CANNOT READ BEAM FILE TABLE IN FILE: ' // file_name, 'AT LINE NUMBER: ' // int_str(n_line))
-      return
+      goto 9000
     endif
 
     if (line == '') cycle
@@ -975,41 +975,41 @@ do
     do ic = 1, n_col
       acol = col(ic)
       select case (downcase(acol))
-      case ('x');                call read_component(acol, p%vec(1), line, n_line, ix, err); if (err) return
-      case ('px');               call read_component(acol, p%vec(2), line, n_line, ix, err); if (err) return
-      case ('y');                call read_component(acol, p%vec(3), line, n_line, ix, err); if (err) return
-      case ('py');               call read_component(acol, p%vec(4), line, n_line, ix, err); if (err) return
-      case ('z');                call read_component(acol, p%vec(5), line, n_line, ix, err); if (err) return
-      case ('pz');               call read_component(acol, p%vec(6), line, n_line, ix, err); if (err) return
-      case ('spin_x');           call read_component(acol, p%spin(1), line, n_line, ix, err); if (err) return
-      case ('spin_y');           call read_component(acol, p%spin(2), line, n_line, ix, err); if (err) return
-      case ('spin_z');           call read_component(acol, p%spin(3), line, n_line, ix, err); if (err) return
-      case ('field_x');          call read_component(acol, p%field(1), line, n_line, ix, err); if (err) return
-      case ('field_y');          call read_component(acol, p%field(2), line, n_line, ix, err); if (err) return
-      case ('phase_x');          call read_component(acol, p%phase(1), line, n_line, ix, err); if (err) return
-      case ('phase_y');          call read_component(acol, p%phase(2), line, n_line, ix, err); if (err) return
-      case ('s', 's_position');  call read_component(acol, p%s, line, n_line, ix, err); if (err) return
-      case ('t', 'time');        call read_component(acol, tim, line, n_line, ix, err); if (err) return; p%t = tim
-      case ('charge');           call read_component(acol, p%charge, line, n_line, ix, err); if (err) return
-      case ('dt_ref');           call read_component(acol, p%dt_ref, line, n_line, ix, err); if (err) return
-      case ('r');                call read_component(acol, p%r, line, n_line, ix, err); if (err) return
-      case ('p0c');              call read_component(acol, p%p0c, line, n_line, ix, err); if (err) return
-      case ('E_potential');      call read_component(acol, p%E_potential, line, n_line, ix, err); if (err) return
-      case ('beta');             call read_component(acol, p%beta, line, n_line, ix, err); if (err) return; beta_found = .true.
-      case ('ix_ele');           call read_component_int(acol, p%ix_ele, line, n_line, ix, err); if (err) return
-      case ('ix_branch');        call read_component_int(acol, p%ix_branch, line, n_line, ix, err); if (err) return
-      case ('ix_user');          call read_component_int(acol, p%ix_user, line, n_line, ix, err); if (err) return
-      case ('direction');        call read_component_int(acol, p%direction, line, n_line, ix, err); if (err) return
-      case ('time_dir');         call read_component_int(acol, p%time_dir, line, n_line, ix, err); if (err) return
-      case ('state');            call read_switch(acol, p%state, line, n_line, err, ix); if (err) return
-      case ('species');          call read_switch(acol, p%species, line, n_line, err, ix); if (err) return
-      case ('location');         call read_switch(acol, p%location, line, n_line, err, ix); if (err) return
+      case ('x');                call read_component(acol, p%vec(1), line, n_line, ix, err); if (err) goto 9000
+      case ('px');               call read_component(acol, p%vec(2), line, n_line, ix, err); if (err) goto 9000
+      case ('y');                call read_component(acol, p%vec(3), line, n_line, ix, err); if (err) goto 9000
+      case ('py');               call read_component(acol, p%vec(4), line, n_line, ix, err); if (err) goto 9000
+      case ('z');                call read_component(acol, p%vec(5), line, n_line, ix, err); if (err) goto 9000
+      case ('pz');               call read_component(acol, p%vec(6), line, n_line, ix, err); if (err) goto 9000
+      case ('spin_x');           call read_component(acol, p%spin(1), line, n_line, ix, err); if (err) goto 9000
+      case ('spin_y');           call read_component(acol, p%spin(2), line, n_line, ix, err); if (err) goto 9000
+      case ('spin_z');           call read_component(acol, p%spin(3), line, n_line, ix, err); if (err) goto 9000
+      case ('field_x');          call read_component(acol, p%field(1), line, n_line, ix, err); if (err) goto 9000
+      case ('field_y');          call read_component(acol, p%field(2), line, n_line, ix, err); if (err) goto 9000
+      case ('phase_x');          call read_component(acol, p%phase(1), line, n_line, ix, err); if (err) goto 9000
+      case ('phase_y');          call read_component(acol, p%phase(2), line, n_line, ix, err); if (err) goto 9000
+      case ('s', 's_position');  call read_component(acol, p%s, line, n_line, ix, err); if (err) goto 9000
+      case ('t', 'time');        call read_component(acol, tim, line, n_line, ix, err); if (err) goto 9000; p%t = tim
+      case ('charge');           call read_component(acol, p%charge, line, n_line, ix, err); if (err) goto 9000
+      case ('dt_ref');           call read_component(acol, p%dt_ref, line, n_line, ix, err); if (err) goto 9000
+      case ('r');                call read_component(acol, p%r, line, n_line, ix, err); if (err) goto 9000
+      case ('p0c');              call read_component(acol, p%p0c, line, n_line, ix, err); if (err) goto 9000
+      case ('E_potential');      call read_component(acol, p%E_potential, line, n_line, ix, err); if (err) goto 9000
+      case ('beta');             call read_component(acol, p%beta, line, n_line, ix, err); if (err) goto 9000; beta_found = .true.
+      case ('ix_ele');           call read_component_int(acol, p%ix_ele, line, n_line, ix, err); if (err) goto 9000
+      case ('ix_branch');        call read_component_int(acol, p%ix_branch, line, n_line, ix, err); if (err) goto 9000
+      case ('ix_user');          call read_component_int(acol, p%ix_user, line, n_line, ix, err); if (err) goto 9000
+      case ('direction');        call read_component_int(acol, p%direction, line, n_line, ix, err); if (err) goto 9000
+      case ('time_dir');         call read_component_int(acol, p%time_dir, line, n_line, ix, err); if (err) goto 9000
+      case ('state');            call read_switch(acol, p%state, line, n_line, err, ix); if (err) goto 9000
+      case ('species');          call read_switch(acol, p%species, line, n_line, err, ix); if (err) goto 9000
+      case ('location');         call read_switch(acol, p%location, line, n_line, err, ix); if (err) goto 9000
       case ('index')
         ! Value is not used but check that it is an integer
         if (.not. is_integer(line(:ix))) then
           call out_io (s_error$, r_name, 'INDEX COLUMN ENTRY IS NOT AN INTEGER: ' // quote(line(:ix)), 'IN FILE: ' // file_name, &
                                          'AT LINE NUMBER: ' // int_str(n_line))
-          return
+          goto 9000
         endif
         call string_trim(line(ix+1:), line, ix)     ! Ignore value
       case default
@@ -1017,7 +1017,7 @@ do
         call out_io(s_error$, r_name, 'COLUMN NAME NOT RECOGNIZED: ' // col(ic), &
                                       'IN FILE: ' // file_name, &
                                       'AT LINE NUMBER: ' // int_str(n_line))
-        return
+        goto 9000
       end select
     enddo
   enddo
@@ -1029,7 +1029,14 @@ enddo
 
 8000 continue
 call bunch_finalizer(bunch, ip, beam_init, beta_found)
+close (iu)
 err_flag = .false.
+return
+
+9000 continue
+close (iu)
+err_flag = .true.
+return
 
 !---------------------------------------------------------------------------------------------------
 contains


### PR DESCRIPTION
## Changes

Update `read_beam_ascii` to always close the file - whether it successfully reads it or not.
In the current code, it is never closed.

This can cause issues in certain scenarios, either through obscure bugs (as linked in the Slack thread below) or just in eventually exhausting file handles / wasting memory.

## Context

https://bmad-simulation.slack.com/archives/C015RUTCRNF/p1779988021009629
