### PR TITLE
Fix segfault in `pipe ele:floor` for girder elements

### DIFF
--- a/regression_tests/pytao/girder_floor/lat.bmad
+++ b/regression_tests/pytao/girder_floor/lat.bmad
@@ -1,0 +1,18 @@
+! Regression test lattice for "pipe ele:floor" on a girder_lord.
+!
+! Original error: `pipe ele:floor g1 beginning` crashed Tao with SIGSEGV
+! because tao_pipe_cmd dereferenced a null pointer when the element was a
+! girder_lord (pointer_to_next_ele returns null for non-super_lord lords).
+
+beginning[beta_a] = 1
+beginning[beta_b] = 1
+beginning[e_tot] = 100e6
+parameter[geometry] = open
+
+p1: pipe, L = 1
+p2: pipe, L = 2
+g1: girder = {p1, p2}
+
+lat: line = (p1, p2)
+
+use, lat

--- a/regression_tests/pytao/girder_floor/lat_multipass.bmad
+++ b/regression_tests/pytao/girder_floor/lat_multipass.bmad
@@ -1,0 +1,23 @@
+! Regression test lattice for "pipe ele:floor" on a girder_lord whose slaves
+! are multipass_lords. The original crash for this configuration was a
+! follow-on to issue #2049: pointer_to_slave(girder, 1) returns the
+! multipass_lord (which lives outside the tracking part of the lattice),
+! and pointer_to_next_ele on a lord returns null. The fix uses
+! find_element_ends to walk through nested lord chains.
+
+beginning[beta_a] = 1
+beginning[beta_b] = 1
+beginning[e_tot] = 100e6
+parameter[geometry] = open
+
+p1: pipe, L = 1
+p2: pipe, L = 2
+
+! Multipass line: p1 and p2 are turned into multipass_lord elements.
+mp_line: line[multipass] = (p1, p2)
+
+g1: girder = {p1, p2}
+
+lat: line = (mp_line, mp_line)
+
+use, lat

--- a/regression_tests/pytao/girder_floor/test_girder_floor.py
+++ b/regression_tests/pytao/girder_floor/test_girder_floor.py
@@ -1,0 +1,59 @@
+"""Regression tests for `pipe ele:floor` on girder_lord elements."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from pytao import SubprocessTao
+
+
+LAT_PATH = Path(__file__).parent / "lat.bmad"
+
+
+@pytest.fixture(scope="module")
+def tao():
+    assert LAT_PATH.is_file(), f"Lattice file not found: {LAT_PATH}"
+    with SubprocessTao(lattice_file=str(LAT_PATH), noplot=True) as t:
+        yield t
+
+
+def test_girder_floor_beginning_does_not_crash(tao):
+    """Regression test: `pipe ele:floor <girder> beginning` used to segfault.
+
+    For a girder_lord the previous implementation called
+    `pointer_to_next_ele(ele, -1)`, which returns null for any lord that is
+    not a super_lord, and then dereferenced the result.
+    """
+    result = tao.ele_floor("g1", where="beginning")
+    # Floor position of the upstream end of the first slave (p1) is the
+    # lattice origin.
+    np.testing.assert_allclose(result["Reference"], [0, 0, 0, 0, 0, 0], atol=1e-12)
+    np.testing.assert_allclose(result["Actual"], [0, 0, 0, 0, 0, 0], atol=1e-12)
+
+
+def test_girder_floor_end_matches_last_slave(tao):
+    """`pipe ele:floor <girder> end` returns the downstream end of the last slave."""
+    girder_end = tao.ele_floor("g1", where="end")
+    last_slave_end = tao.ele_floor("p2", where="end")
+    np.testing.assert_allclose(girder_end["Reference"], last_slave_end["Reference"], atol=1e-12)
+    np.testing.assert_allclose(girder_end["Actual"], last_slave_end["Actual"], atol=1e-12)
+    # Total length p1+p2 = 3 m, lattice is along z.
+    np.testing.assert_allclose(girder_end["Reference"], [0, 0, 3, 0, 0, 0], atol=1e-12)
+
+
+def test_girder_floor_beginning_matches_first_slave(tao):
+    """`pipe ele:floor <girder> beginning` returns the upstream end of the first slave."""
+    girder_begin = tao.ele_floor("g1", where="beginning")
+    first_slave_begin = tao.ele_floor("p1", where="beginning")
+    np.testing.assert_allclose(
+        girder_begin["Reference"], first_slave_begin["Reference"], atol=1e-12
+    )
+    np.testing.assert_allclose(girder_begin["Actual"], first_slave_begin["Actual"], atol=1e-12)
+
+
+def test_girder_floor_center(tao):
+    """`pipe ele:floor <girder> center` returns the girder's own floor position."""
+    result = tao.ele_floor("g1", where="center")
+    # Center of a girder is the midpoint of the slave span: z = (0 + 3) / 2 = 1.5.
+    np.testing.assert_allclose(result["Reference"], [0, 0, 1.5, 0, 0, 0], atol=1e-12)
+    np.testing.assert_allclose(result["Actual"], [0, 0, 1.5, 0, 0, 0], atol=1e-12)

--- a/regression_tests/pytao/girder_floor/test_girder_floor.py
+++ b/regression_tests/pytao/girder_floor/test_girder_floor.py
@@ -8,12 +8,20 @@ from pytao import SubprocessTao
 
 
 LAT_PATH = Path(__file__).parent / "lat.bmad"
+LAT_MULTIPASS_PATH = Path(__file__).parent / "lat_multipass.bmad"
 
 
 @pytest.fixture(scope="module")
 def tao():
     assert LAT_PATH.is_file(), f"Lattice file not found: {LAT_PATH}"
     with SubprocessTao(lattice_file=str(LAT_PATH), noplot=True) as t:
+        yield t
+
+
+@pytest.fixture(scope="module")
+def tao_multipass():
+    assert LAT_MULTIPASS_PATH.is_file(), f"Lattice file not found: {LAT_MULTIPASS_PATH}"
+    with SubprocessTao(lattice_file=str(LAT_MULTIPASS_PATH), noplot=True) as t:
         yield t
 
 
@@ -57,3 +65,18 @@ def test_girder_floor_center(tao):
     # Center of a girder is the midpoint of the slave span: z = (0 + 3) / 2 = 1.5.
     np.testing.assert_allclose(result["Reference"], [0, 0, 1.5, 0, 0, 0], atol=1e-12)
     np.testing.assert_allclose(result["Actual"], [0, 0, 1.5, 0, 0, 0], atol=1e-12)
+
+
+def test_girder_floor_multipass_does_not_crash(tao_multipass):
+    """Regression test: `pipe ele:floor <girder> beginning` used to segfault
+    when the girder's slaves are multipass_lord elements.
+
+    pointer_to_slave(girder, 1) returns the multipass_lord (which is not in
+    the tracking part of the lattice), so pointer_to_next_ele returned null.
+    The fix descends through nested lord chains via find_element_ends.
+    """
+    begin = tao_multipass.ele_floor("g1", where="beginning")
+    end = tao_multipass.ele_floor("g1", where="end")
+    # First pass of the multipass line is at z in [0, 3].
+    np.testing.assert_allclose(begin["Reference"], [0, 0, 0, 0, 0, 0], atol=1e-12)
+    np.testing.assert_allclose(end["Reference"], [0, 0, 3, 0, 0, 0], atol=1e-12)

--- a/tao/code/tao_pipe_cmd.f90
+++ b/tao/code/tao_pipe_cmd.f90
@@ -9531,7 +9531,7 @@ end subroutine write_this_floor
 recursive subroutine write_this_ele_floor(ele, loc, can_vary, suffix)
 
 type (ele_struct), target :: ele
-type (ele_struct), pointer :: ele0
+type (ele_struct), pointer :: ele0, slave_ele
 
 integer n, ie, loc
 logical can_vary
@@ -9545,6 +9545,31 @@ if (ele%lord_status /= super_lord$ .and. ele%lord_status /= girder_lord$ .and. e
     ele0 => pointer_to_slave(ele, ie)
     call write_this_ele_floor(ele0, loc, can_vary, '-Slave' // int_str(ie))
   enddo
+  return
+endif
+
+! A girder_lord has no place on the s-axis, so beginning/end refer to the
+! upstream end of the first slave and the downstream end of the last slave.
+
+if (ele%lord_status == girder_lord$) then
+  select case (loc)
+  case (1)
+    slave_ele => pointer_to_slave(ele, 1)
+    if (slave_ele%ix_ele == 0) then
+      ele0 => slave_ele
+    else
+      ele0 => pointer_to_next_ele(slave_ele, -1)
+    endif
+    call write_this_floor(ele0%floor, 'Reference' // suffix, can_vary)
+    call write_this_floor(ele_geometry_with_misalignments (slave_ele, 0.0_rp), 'Actual' // suffix, .false.)
+  case (2)
+    call write_this_floor(ele%floor, 'Reference' // suffix, can_vary)
+    call write_this_floor(ele_geometry_with_misalignments (ele), 'Actual' // suffix, .false.)
+  case (3)
+    slave_ele => pointer_to_slave(ele, ele%n_slave)
+    call write_this_floor(slave_ele%floor, 'Reference' // suffix, can_vary)
+    call write_this_floor(ele_geometry_with_misalignments (slave_ele), 'Actual' // suffix, .false.)
+  end select
   return
 endif
 

--- a/tao/code/tao_pipe_cmd.f90
+++ b/tao/code/tao_pipe_cmd.f90
@@ -9531,7 +9531,7 @@ end subroutine write_this_floor
 recursive subroutine write_this_ele_floor(ele, loc, can_vary, suffix)
 
 type (ele_struct), target :: ele
-type (ele_struct), pointer :: ele0, slave_ele
+type (ele_struct), pointer :: ele0, ele1, ele2
 
 integer n, ie, loc
 logical can_vary
@@ -9549,26 +9549,29 @@ if (ele%lord_status /= super_lord$ .and. ele%lord_status /= girder_lord$ .and. e
 endif
 
 ! A girder_lord has no place on the s-axis, so beginning/end refer to the
-! upstream end of the first slave and the downstream end of the last slave.
+! upstream end of the first tracking slave and the downstream end of the last
+! tracking slave. find_element_ends walks through nested lord chains
+! (multipass_lord, super_lord, nested girders) to reach a tracking element.
 
 if (ele%lord_status == girder_lord$) then
+  call find_element_ends(ele, ele1, ele2)
+  if (.not. associated(ele1) .or. .not. associated(ele2)) then
+    call invalid ('UNABLE TO FIND ENDS OF GIRDER: ' // ele%name)
+    return
+  endif
   select case (loc)
-  case (1)
-    slave_ele => pointer_to_slave(ele, 1)
-    if (slave_ele%ix_ele == 0) then
-      ele0 => slave_ele
-    else
-      ele0 => pointer_to_next_ele(slave_ele, -1)
-    endif
-    call write_this_floor(ele0%floor, 'Reference' // suffix, can_vary)
-    call write_this_floor(ele_geometry_with_misalignments (slave_ele, 0.0_rp), 'Actual' // suffix, .false.)
-  case (2)
+  case (1)  ! beginning
+    ! ele1 is the element immediately upstream of the first tracking slave,
+    ! so ele1%floor is the upstream end of the first tracking slave.
+    call write_this_floor(ele1%floor, 'Reference' // suffix, can_vary)
+    ele0 => pointer_to_next_ele(ele1, +1)
+    call write_this_floor(ele_geometry_with_misalignments (ele0, 0.0_rp), 'Actual' // suffix, .false.)
+  case (2)  ! center
     call write_this_floor(ele%floor, 'Reference' // suffix, can_vary)
     call write_this_floor(ele_geometry_with_misalignments (ele), 'Actual' // suffix, .false.)
-  case (3)
-    slave_ele => pointer_to_slave(ele, ele%n_slave)
-    call write_this_floor(slave_ele%floor, 'Reference' // suffix, can_vary)
-    call write_this_floor(ele_geometry_with_misalignments (slave_ele), 'Actual' // suffix, .false.)
+  case (3)  ! end
+    call write_this_floor(ele2%floor, 'Reference' // suffix, can_vary)
+    call write_this_floor(ele_geometry_with_misalignments (ele2), 'Actual' // suffix, .false.)
   end select
   return
 endif
@@ -9582,14 +9585,14 @@ else
 endif
 
 select case (loc)
-case (1)
+case (1)  ! beginning
   call write_this_floor(ele0%floor, 'Reference' // suffix, can_vary)
   call write_this_floor(ele_geometry_with_misalignments (ele, 0.0_rp), 'Actual' // suffix, .false.)
-case (2)
+case (2)  ! center
   call ele_geometry(ele0%floor, ele, floor, 0.5_rp)
   call write_this_floor(floor, 'Reference' // suffix, can_vary)
   call write_this_floor(ele_geometry_with_misalignments (ele, 0.5_rp), 'Actual' // suffix, .false.)
-case (3)
+case (3)  ! end
   call write_this_floor(ele%floor, 'Reference' // suffix, can_vary)
   call write_this_floor(ele_geometry_with_misalignments (ele), 'Actual' // suffix, .false.)
 end select


### PR DESCRIPTION
Fixes #2049.

## Problem

Running Tao with a lattice containing a `girder` element and querying the floor coordinates of that girder crashed with a segmentation fault:

```
tao -lat lat.bmad -noplot -command "pipe ele:floor g1 beginning"
```

Minimal reproducer:

```bmad
beginning[beta_a] = 1
beginning[beta_b] = 1
beginning[e_tot] = 100e6
parameter[geometry] = open

p1: pipe, L = 1
p2: pipe, L = 2
g1: girder = {p1, p2}

lat: line = (p1, p2)
use, lat
```

```
Program received signal SIGSEGV: Segmentation fault - invalid memory reference.
```

The same crash also occurred for the more common case where a girder's slaves are `multipass_lord` elements (e.g. a cryomodule girder over a multipass linac line).

## Cause

In `write_this_ele_floor` ([tao/code/tao_pipe_cmd.f90](../tao/code/tao_pipe_cmd.f90)), the code special-cased `super_lord$` and `girder_lord$` to skip the slave recursion, then unconditionally called:

```fortran
ele0 => pointer_to_next_ele(ele, -1)
```

`pointer_to_next_ele` returns `null()` for any lord that is not a `super_lord`, so `ele0%floor` on the next line dereferenced a null pointer for every girder.

A naive fix that descends one level with `pointer_to_slave(girder, 1)` is not enough either: when the girder's slaves are themselves multipass_lord elements, the result still lives outside the tracking part of the lattice and `pointer_to_next_ele` still returns null.

## Fix

Added a dedicated `girder_lord` branch in `write_this_ele_floor` that uses `find_element_ends`, which already walks through nested lord chains (`multipass_lord`, `super_lord`, nested girders) down to actual tracking elements:

- `beginning` → upstream floor of the first tracking slave (from `ele1` returned by `find_element_ends`)
- `center`    → the girder's own `ele%floor` (midpoint of the slave span)
- `end`       → downstream floor of the last tracking slave (`ele2`)

If `find_element_ends` cannot resolve the ends (e.g. an ill-defined girder), the routine emits an `invalid` message instead of dereferencing null.

## Verification

Before the fix, both the minimal reproducer above and a real linac model with a multipass cryomodule girder (`L1_CM1`) segfaulted on `pipe ele:floor <girder> beginning`. After the fix, both return sensible floor coordinates:

```
Tao: pipe ele:floor g1 beginning
Reference;REAL_ARR;F;  0.00...E+00;  0.00...E+00;  0.00...E+00; ...

Tao: pipe ele:floor g1 center
Reference;REAL_ARR;F;  0.00...E+00;  0.00...E+00;  1.50...E+00; ...

Tao: pipe ele:floor g1 end
Reference;REAL_ARR;F;  0.00...E+00;  0.00...E+00;  3.00...E+00; ...
```

## Tests

Added [`regression_tests/pytao/girder_floor/`](../regression_tests/pytao/girder_floor/) with two minimal lattices and a pytest-based regression test (`test_girder_floor.py`):

- `lat.bmad` — simple girder over two pipes
- `lat_multipass.bmad` — girder whose slaves are multipass_lord elements

Test cases:

- `test_girder_floor_beginning_does_not_crash` — confirms `pipe ele:floor g1 beginning` no longer crashes the subprocess
- `test_girder_floor_beginning_matches_first_slave` — confirms `beginning` matches the upstream floor of the first slave
- `test_girder_floor_end_matches_last_slave` — confirms `end` matches the downstream floor of the last slave
- `test_girder_floor_center` — confirms `center` matches the midpoint of the slave span
- `test_girder_floor_multipass_does_not_crash` — confirms the girder-over-multipass case (the original real-world crash) returns sensible coordinates without crashing

All five cases pass against the patched build.

## Files changed

- `tao/code/tao_pipe_cmd.f90` — replaced the broken `pointer_to_next_ele` path with a `girder_lord` branch backed by `find_element_ends`.
- `regression_tests/pytao/girder_floor/lat.bmad` — minimal girder lattice.
- `regression_tests/pytao/girder_floor/lat_multipass.bmad` — girder over multipass lattice.
- `regression_tests/pytao/girder_floor/test_girder_floor.py` — pytest regression tests (5 cases).

---

## Acknowledgement

This PR was prepared with assistance from GitHub Copilot (Claude Opus 4.7, Anthropic) running in the VS Code agent surface. The model performed the codebase exploration, diagnosis, edits, build, and test authoring; all changes were reviewed and verified locally.
