### PR TITLE
Fix: a `radiation_map_setup` failure aborts the entire Tao beam track ("BEAM NOT SAVED AT ELEMENT")

### DIFF
--- a/bmad/modules/radiation_mod.f90
+++ b/bmad/modules/radiation_mod.f90
@@ -198,7 +198,13 @@ branch => pointer_to_branch(ele)
 
 if (present(ref_orbit_in)) then
   ref_orb_in = ref_orbit_in
+  ! Radiation (in particular the random fluctuations) must not be applied to the deterministic
+  ! reference orbit used to seed the radiation map.
+  bmad_com_save = bmad_com
+  bmad_com%radiation_damping_on = .false.
+  bmad_com%radiation_fluctuations_on = .false.
   call track1(ref_orb_in, ele, branch%param, ref_orb_out)
+  bmad_com = bmad_com_save
   if (ref_orb_out%state /= alive$) then
     err_flag = .true.
     call out_io (s_error$, r_name, 'Reference particle lost while tracking through: ' // ele_full_name(ele))

--- a/tao/code/tao_lattice_calc_mod.f90
+++ b/tao/code/tao_lattice_calc_mod.f90
@@ -563,10 +563,8 @@ do
         if (radiation_on) then
           call radiation_map_setup(ele, err, bunch_params%centroid)
           if (err) then
-            call out_io (s_error$, r_name, 'RADIATION MAP SETUP WHILE BEAM TRACKING ERROR THROUGH ELEMENT: ' // ele_full_name(ele), &
-                                           'STOPPING BEAM TRACKING.')
-            calc_ok = .false.
-            return
+            call stop_beam_track_on_rad_error()
+            exit
           endif
         endif
         call track_beam (lat, beam, branch%ele(ie-1), ele, err, centroid = tao_branch%orbit, bunch_tracks = bunch_params_comb)
@@ -583,6 +581,10 @@ do
         if (radiation_on) then
           call calc_bunch_params(beam%bunch(s%global%bunch_to_plot), bunch_params, err)
           call radiation_map_setup(slice_ele, err, bunch_params%centroid)
+          if (err) then
+            call stop_beam_track_on_rad_error()
+            exit
+          endif
         endif
 
         do i = 1, size(beam%bunch)
@@ -728,6 +730,23 @@ endif
 if (associated(target_ele%rad_map)) rad_map_save = target_ele%rad_map
 
 end function point_to_this_ele
+
+!-----------------------------------------------------------------------
+! contains
+
+! A radiation_map_setup failure for one element is not fatal: keep the beam tracked so far
+! and stop gracefully (like the too-many-particles-lost case) instead of discarding everything.
+
+subroutine stop_beam_track_on_rad_error ()
+
+call out_io (s_warn$, r_name, &
+        'RADIATION MAP SETUP FAILED WHILE BEAM TRACKING THROUGH ELEMENT ' // trim(ele_loc_name(ele)) // ': ' // trim(ele%name), &
+        'WILL STOP TRACKING AT THIS ELEMENT.')
+ix_track = ie
+tao_model_ele(ie)%beam = beam   ! Make sure the beam tracked so far is saved.
+calc_ok = .false.
+
+end subroutine stop_beam_track_on_rad_error
 
 end subroutine tao_beam_track
 


### PR DESCRIPTION
## Summary

When beam tracking in Tao with radiation on (`bmad_com[radiation_fluctuations_on] = T` and/or `bmad_com[radiation_damping_on] = T`), a failure inside `radiation_map_setup` for a single element caused the **entire** beam track to be discarded. The already-tracked beam was never saved, so any subsequent query of the beam (e.g. `python bunch1 <ele>|model 1 state`, `show beam`, datum evaluation) failed with `BEAM NOT SAVED AT ELEMENT`, even at elements upstream of the failure where a perfectly good beam existed.

This PR makes a per-element `radiation_map_setup` failure non-fatal: Tao now keeps the beam tracked so far and stops gracefully at the offending element — the same behavior already used when too many particles are lost — instead of throwing everything away. It also stops the radiation map's deterministic reference-orbit track from being perturbed by the user's radiation flags.

## Background

Issue #2062 was reported with a minimal working example that demonstrated the `BEAM NOT SAVED AT ELEMENT` failure. The original symptom surfaced after commit `4bb23ee83` (PR #2059) correctly changed a `return` to `goto 9000` in `ele_compute_ref_energy_and_time` (`bmad/low_level/compute_reference_energy.f90`). That change restored proper radiation-flag bookkeeping (previously a `super_lord` element could `return` early and leave radiation silently disabled globally). With radiation now correctly honored, the latent Tao abort in `tao_beam_track` became reachable — so the `goto` fix did not introduce this bug, it merely exposed it. The MWE in #2062 forces radiation on directly, so it reproduces on any build independent of that bookkeeping change.

## Root cause

In `tao_beam_track` (`tao/code/tao_lattice_calc_mod.f90`), the non-sliced tracking path did:

```fortran
if (radiation_on) then
  call radiation_map_setup(ele, err, bunch_params%centroid)
  if (err) then
    call out_io (s_error$, r_name, 'RADIATION MAP SETUP WHILE BEAM TRACKING ERROR THROUGH ELEMENT: ' // ele_full_name(ele), &
                                   'STOPPING BEAM TRACKING.')
    calc_ok = .false.
    return            ! <-- aborts the whole routine, discarding the saved beam
  endif
endif
```

The bare `return` exits `tao_beam_track` immediately. The normal lost-particle handling (`tao_too_many_particles_lost`, which saves the beam via `tao_model_ele(ie)%beam = beam` and `exit`s the loop so the post-loop bookkeeping runs) never gets a chance to execute. As a result the beam is never stored for any element, and downstream queries report `BEAM NOT SAVED AT ELEMENT`.

The sliced-element path (used when comb saving is on) had the mirror-image problem: it called `radiation_map_setup` but ignored the returned `err` entirely, so a failure there was silently dropped.

A secondary contributing issue lives in `radiation_map_setup` itself (`bmad/modules/radiation_mod.f90`). When called with the optional `ref_orbit_in` argument, it performs a diagnostic `track1` of the reference orbit used to seed the radiation map **before** it locally disables radiation damping. Because the user's radiation flags are still active, this deterministic seed orbit can be perturbed by the random radiation fluctuations, making the map setup spuriously sensitive (and, in edge cases, more likely to report a lost reference particle).

## The fix

### `tao/code/tao_lattice_calc_mod.f90`

A failure in `radiation_map_setup` (an auxiliary radiation-map calculation) should not discard the beam that has already been tracked. Both the non-sliced and sliced paths now call a small contained helper and `exit` the tracking loop, so the existing post-loop bookkeeping runs and the beam tracked so far is preserved:

```fortran
subroutine stop_beam_track_on_rad_error ()

call out_io (s_warn$, r_name, &
        'RADIATION MAP SETUP FAILED WHILE BEAM TRACKING THROUGH ELEMENT ' // trim(ele_loc_name(ele)) // ': ' // trim(ele%name), &
        'WILL STOP TRACKING AT THIS ELEMENT.')
ix_track = ie
tao_model_ele(ie)%beam = beam   ! Make sure the beam tracked so far is saved.
calc_ok = .false.

end subroutine stop_beam_track_on_rad_error
```

This mirrors the existing `tao_too_many_particles_lost` handling: record the stop element in `ix_track`, save the beam, set `calc_ok = .false.`, and let the loop exit cleanly. The previously-ignored error on the sliced path is now handled the same way.

### `bmad/modules/radiation_mod.f90`

The deterministic reference-orbit `track1` used to seed the radiation map now temporarily disables radiation damping and fluctuations around that single call, then restores `bmad_com`:

```fortran
if (present(ref_orbit_in)) then
  ref_orb_in = ref_orbit_in
  ! Radiation (in particular the random fluctuations) must not be applied to the deterministic
  ! reference orbit used to seed the radiation map.
  bmad_com_save = bmad_com
  bmad_com%radiation_damping_on = .false.
  bmad_com%radiation_fluctuations_on = .false.
  call track1(ref_orb_in, ele, branch%param, ref_orb_out)
  bmad_com = bmad_com_save
  if (ref_orb_out%state /= alive$) then
    ...
```

## Behavior change

Before: with radiation on, a single-element `radiation_map_setup` failure aborts the whole track and no beam is saved anywhere → `BEAM NOT SAVED AT ELEMENT` on any beam query.

After: the same failure emits a warning, saves the beam tracked up to that element, and stops gracefully. Beam queries upstream of (and at) the stop element succeed; `calc_ok` is still set `.false.` so callers know the track did not complete normally — exactly the contract already used for the too-many-particles-lost case.

## Verification

Built with `./CondaCompile.bash` (GNU Fortran 15.1.0, macOS, Apple Silicon).

Using the MWE from #2062 (radiation forced on, single particle steered into a bend aperture so the reference particle is lost in `radiation_map_setup`):

| Binary | `radiation_fluctuations_on = T` (particle lost in bend) |
| --- | --- |
| Pre-fix | `"pipe bunch1 BB\|model 1 state": BEAM NOT SAVED AT ELEMENT.` |
| Patched | No error — beam saved; graceful `WILL STOP TRACKING AT THIS ELEMENT` warning |

The `radiation_test` regression test still passes within its stated tolerances. (Its diffs are pre-existing sub-`1e-17` floating-point noise and do not exercise the changed `ref_orbit_in` path, which is only reached via `tao_beam_track`.)

## Files changed

- `tao/code/tao_lattice_calc_mod.f90` — graceful handling of a `radiation_map_setup` failure in `tao_beam_track` (both the non-sliced and sliced paths); new contained helper `stop_beam_track_on_rad_error`.
- `bmad/modules/radiation_mod.f90` — disable radiation damping/fluctuations around the reference-orbit `track1` in `radiation_map_setup`.

## Acknowledgement

The diagnosis, minimal working example (#2062), and this fix were developed with the assistance of Claude (Anthropic) via GitHub Copilot.
