### PR TITLE
allow alias to be set for overlay elements

### DIFF
--- a/bmad/modules/attribute_mod.f90
+++ b/bmad/modules/attribute_mod.f90
@@ -3247,6 +3247,9 @@ end select
 
 if (ele%key == overlay$ .or. ele%key == group$) then
   if (attrib_name == 'IS_ON') return
+  if (attrib_name == 'TYPE') return
+  if (attrib_name == 'ALIAS') return
+  if (attrib_name == 'DESCRIP') return
   if (all(attrib_name /= ele%control%var%name)) then
     call it_is_not_free (free, ele, ix_attrib, does_not_exist$, 'IS NOT A VALID CONTROL VARIABLE', skip = .true.)
   endif

--- a/tao/version/tao_version_mod.f90
+++ b/tao/version/tao_version_mod.f90
@@ -5,5 +5,5 @@
 !-
 
 module tao_version_mod
-character(*), parameter :: tao_version_date = "2026/06/17 15:59:46"
+character(*), parameter :: tao_version_date = "2026/06/22 20:27:32"
 end module


### PR DESCRIPTION
TYPE, ALIAS, and DESCRIP are listed in the Bmad manual as valid parameters for groups and overlays.  Also, they can be set OK via the lattice file.  However, tao says they are not free.

The not free error appears to be a bug, which this PR fixes.