### PR TITLE
Fix: `radiation_map_setup` reference-orbit loss aborts beam track and discards saved beam

### DIFF
--- a/bmad/modules/radiation_mod.f90
+++ b/bmad/modules/radiation_mod.f90
@@ -198,17 +198,21 @@ branch => pointer_to_branch(ele)
 
 bmad_com_save = bmad_com
 bmad_com%radiation_damping_on = .false.
+bmad_com%radiation_fluctuations_on = .false.
 bmad_com%spin_tracking_on = .false.
 
 if (present(ref_orbit_in)) then
   ref_orb_in = ref_orbit_in
   ! Radiation (in particular the random fluctuations) must not be applied to the deterministic
-  ! reference orbit used to seed the radiation map.
+  ! reference orbit used to seed the radiation map. Fluctuations are disabled above.
   call track1(ref_orb_in, ele, branch%param, ref_orb_out)
+  ! The radiation map is an auxiliary calculation. If the supplied reference orbit (e.g. a bunch
+  ! centroid) is lost here -- for example, because it is outside an aperture -- fall back to the
+  ! element's design reference orbit instead of failing. The actual particle loss is handled by
+  ! the normal beam-tracking machinery.
   if (ref_orb_out%state /= alive$) then
-    err_flag = .true.
-    call out_io (s_error$, r_name, 'Reference particle lost while tracking through: ' // ele_full_name(ele))
-    goto 8000
+    ref_orb_in  = ele%map_ref_orb_in
+    ref_orb_out = ele%map_ref_orb_out
   endif
 else
   ref_orb_in  = ele%map_ref_orb_in


### PR DESCRIPTION
## Summary

During beam tracking in Tao with radiation on (`bmad_com[radiation_fluctuations_on] = T` and/or `radiation_damping_on = T`), a failure inside `radiation_map_setup` for a single element could abort the **entire** beam track. As a result the beam was not saved at any element (including elements upstream of the failure that were already tracked), and subsequent `pipe/python bunch1 <ele> ...` queries failed with `BEAM NOT SAVED AT ELEMENT. / INVALID`.

With radiation off, the same particle loss was handled gracefully: tracking stopped at the loss element, the beam was saved there, and the query succeeded. This PR makes the radiation-on path behave identically.

## Root cause

`radiation_map_setup` (in `bmad/modules/radiation_mod.f90`) is an auxiliary per-element calculation. When seeded with a supplied reference orbit (the bunch centroid), it ran a diagnostic `track1` of that orbit and, if the orbit was lost, returned `err_flag = .true.`. Two problems compounded this:

1. The diagnostic `track1` disabled `radiation_damping_on` and `spin_tracking_on` but **not** `radiation_fluctuations_on`, despite a code comment asserting that fluctuations "must not be applied to the deterministic reference orbit." A bad stochastic draw could therefore lose the reference particle non-deterministically, independent of the actual beam.

2. A lost reference orbit (for example, a bunch centroid outside an aperture) was treated as a hard error rather than falling back to the element's design reference orbit.

On the Tao side, `tao_beam_track` (in `tao/code/tao_lattice_calc_mod.f90`) propagated this error via a bare `return` that ran *before* `track_beam`, pre-empting the existing graceful lost-particle handling (`tao_too_many_particles_lost`, which saves the beam and `exit`s). The sliced-element branch of the same routine ignored the `radiation_map_setup` `err` entirely, so the hard abort only happened on the non-sliced path.

This became visible after commit 4bb23ee83 ("Fix obscure recent radiation on/off bookkeeping bug in `ele_compute_ref_energy_and_time`", #2059), which correctly changed a `return` to `goto 9000` so the requested radiation state is honored. Before that fix, lattices requesting radiation were silently tracking with radiation OFF, which masked this issue.

## Changes

### `bmad/modules/radiation_mod.f90` — `radiation_map_setup` (primary fix)

- Disable `bmad_com%radiation_fluctuations_on` (in addition to the existing `radiation_damping_on` and `spin_tracking_on`) before the diagnostic `track1`, so the reference-orbit track is fully deterministic and is never lost due to a stochastic photon-emission draw. This matches the existing code comment's stated intent.
- When the supplied reference orbit is lost during the diagnostic track, fall back to the element's design reference orbit (`ele%map_ref_orb_in` / `ele%map_ref_orb_out`) instead of setting `err_flag` and bailing out. The radiation map is auxiliary; the real particle loss is handled by the normal beam-tracking machinery.

### `tao/code/tao_lattice_calc_mod.f90` — `tao_beam_track` (defense-in-depth)

- Replace the bare `return` on a `radiation_map_setup` failure with a graceful stop that mirrors the existing too-many-particles-lost handling: save the beam tracked so far (`tao_model_ele(ie)%beam = beam`), set `ix_track` / `calc_ok = .false.`, and `exit` the tracking loop instead of discarding everything. The same handling is applied to the sliced-element branch (which previously ignored the error). This guarantees that if `radiation_map_setup` ever genuinely fails for some other reason, the beam tracked up to that point is preserved rather than thrown away.

## Minimal working example

A 4-element lattice (drift, sbend, drift, marker) with a tight aperture on the bend so a single off-axis particle is deterministically lost in the bend. No field maps and no PyTao; plain Tao startup-command scripts only. Files are in `mwe/`:

- `mwe.bmad`
- `rad_on.startup`  (radiation fluctuations on)
- `rad_off.startup` (radiation fluctuations off, for contrast)

The only difference between the two startup scripts is `radiation_fluctuations_on`. The MWE forces this flag directly, so it does not depend on the `ele_compute_ref_energy_and_time` change from #2059 and reproduces on any current build.

Reproduce:

```
tao -lat mwe.bmad -noplot -startup rad_on.startup  -command "python bunch1 BB|model 1 state; exit"
tao -lat mwe.bmad -noplot -startup rad_off.startup -command "python bunch1 BB|model 1 state; exit"
```

## Before / after

Before the fix, the radiation-on case aborted:

```
[ERROR | ...] radiation_map_setup:
    Reference particle lost while tracking through: BB (2)
[ERROR | ...] tao_beam_track:
    RADIATION MAP SETUP WHILE BEAM TRACKING ERROR THROUGH ELEMENT: BB (2)
    STOPPING BEAM TRACKING.
[ERROR | ...] tao_pipe_cmd:
    "pipe bunch1 BB|model 1 state": BEAM NOT SAVED AT ELEMENT.
INVALID
```

After the fix, the radiation-on case behaves identically to the radiation-off case: the lost particle is handled gracefully, the beam is saved at `BB`, and the query succeeds.

```
1 particle(s) lost at element 2: BB  Total lost: 1  of 1
[WARNING] tao_beam_track:
    TOO MANY PARTICLES HAVE BEEN LOST AT ELEMENT 2: BB
    WILL STOP TRACKING AT ELEMENT: BB (2)
```

## Verification

- Rebuilt Bmad (production) via `CondaCompile.bash`; build completed at 100% with no errors.
- `mwe/rad_on.startup` and `mwe/rad_off.startup` now produce identical lost-particle handling output; the `radiation_map_setup` error and the `RADIATION MAP SETUP FAILED` / `BEAM NOT SAVED AT ELEMENT` / `INVALID` messages are gone.
- `regression_tests/radiation_test`: passes; output is deterministic across repeated runs (two consecutive runs are byte-for-byte identical). Remaining diffs versus the committed reference are pre-existing cross-build round-off noise (magnitudes ~1e-23 to 1e-29, far below the test's `1e-12` / `1e-16` tolerances). This test exercises neither changed code path (it never enables `radiation_fluctuations_on` and never passes `ref_orbit_in`), so it is unaffected by the change.

## Environment

- Compiler: GNU Fortran (gcc) 15.1.0
- OS: macOS 26.5.1, Apple Silicon
- Built with the conda-forge `bmad-build` toolchain

## Acknowledgement

This bug was tracked down, simplified to the minimal working example, and fixed with the assistance of Claude (Anthropic Claude Opus 4.8) operating as a GitHub Copilot coding agent in VS Code.
