### PR TITLE
CLN: remove dead code in attribute_set_bookkeeping

### DIFF
--- a/bmad/code/attribute_set_bookkeeping.f90
+++ b/bmad/code/attribute_set_bookkeeping.f90
@@ -19,7 +19,6 @@ implicit none
 type (ele_struct) ele
 type (all_pointer_struct), optional :: attrib_ptr
 type (all_pointer_struct) a_ptr
-type (branch_struct), pointer :: branch
 
 character(*) attrib_name
 logical err_flag
@@ -50,7 +49,6 @@ case ('DETA_Z_DS'); ele%z%etap = real_garbage$
 case default
   if (.not. field_attribute_free(ele, attrib_name)) then
     ele%field_master = .not. ele%field_master
-    branch => pointer_to_branch(ele)
     call attribute_bookkeeper(ele, force_bookkeeping = .true.)
     ele%field_master = .not. ele%field_master
   endif


### PR DESCRIPTION
Minor tweak:

`branch` is entirely unused here in `attribute_set_bookkeeping`. May as well remove it.