### PR TITLE
Fix intermittent EM_FIELD1 failure: uninitialised icoef in PTC pancake build (#2044)

### DIFF
--- a/bmad/ptc/ele_to_fibre.f90
+++ b/bmad/ptc/ele_to_fibre.f90
@@ -720,6 +720,7 @@ if (ptc_key%magnet == 'PANCAKEBMADZERO') then
   call init_pancake (max_order+1, 2)
 
   field = 0
+  icoef = 0   ! Must be zeroed: daall0_pancake treats a nonzero handle as an already-allocated vector.
   call alloc_pancake(field)
   call daall0_pancake(icoef)
 


### PR DESCRIPTION
## Problem

`mat6_calc_method_test::EM_FIELD1:Taylor:*` fails intermittently on macOS CI (#2044).
On failing runs the em_field transfer matrix collapses toward that of a drift (the
coupling terms drop ~75x), i.e. the `gen_grad_map` field is intermittently not applied.

## Root cause

In `bmad/ptc/ele_to_fibre.f90`, when building the PTC "pancake" for an em_field element
with a `gen_grad_map`, a scratch DA vector was allocated via `daall0_pancake(icoef)`
**without first zeroing `icoef`**:

```fortran
field = 0
call alloc_pancake(field)
call daall0_pancake(icoef)   ! icoef uninitialised
```

`daall0` (`forest/code/c_dabnew_pancake.f90:839`) treats a handle in `(0, nda_dab]` as an
*already-allocated* vector and returns it unchanged. So whenever the uninitialised stack
value of `icoef` happened to fall in that range, the scratch vector **aliased an existing
DA vector**; the field map was then accumulated into the wrong storage and the element
tracked essentially as a drift. Because the trigger is a stack value, it is intermittent
and platform/build dependent — hence a flaky macOS-only failure. `field` was already zeroed
just above for exactly this reason; `icoef` was missed.

This is an integer used in a conditional, so it is invisible to `gfortran -Wuninitialized`
and to `-finit-real=snan`; it was pinpointed with `valgrind --track-origins=yes`
(origin: `ele_to_fibre` stack, use: `c_dabnew_pancake.f90:839`).

## Fix

One line — zero `icoef` before allocation, mirroring `field`.

## Validation

Built debug on Linux and ran the em_field element under Valgrind:

| | uninitialised-value errors | EM_FIELD1 field |
|---|---|---|
| before | 2 (at `daall0` / `ele_to_fibre`) | — |
| after  | **0** | correct |

`mat6_calc_method_test` continues to pass within tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)