### PR TITLE
Fix uninitialised icoef in ele_to_fibre pancake build (#2044)

### DIFF
--- a/bmad/ptc/ele_to_fibre.f90
+++ b/bmad/ptc/ele_to_fibre.f90
@@ -720,6 +720,7 @@ if (ptc_key%magnet == 'PANCAKEBMADZERO') then
   call init_pancake (max_order+1, 2)
 
   field = 0
+  icoef = 0   ! Must be zeroed: daall0_pancake treats a nonzero handle as an already-allocated vector.
   call alloc_pancake(field)
   call daall0_pancake(icoef)
 


### PR DESCRIPTION
When building the PTC "pancake" for an em_field element with a gen_grad_map, ele_to_fibre allocated a scratch DA vector via daall0_pancake(icoef) without first zeroing icoef. daall0 treats a handle in (0, nda_dab] as an ALREADY allocated vector and returns it unchanged, so whenever the uninitialised stack value of icoef happened to land in that range, the scratch vector aliased an existing DA vector. The field map was then built into the wrong storage and the element tracked essentially as a drift -- intermittently and only on some platforms/heaps, which is why it showed up as a flaky macOS CI failure on mat6_calc_method_test::EM_FIELD1:Taylor:*.

`field` was already zeroed just above for the same reason; icoef was missed. Pinpointed with valgrind --track-origins=yes (origin: ele_to_fibre stack, use: c_dabnew_pancake.f90:839).