### PR TITLE
Fix: Beam tracking is slow when an SR wake is defined but `sr_wakes_on = False`

### DIFF
--- a/bmad/multiparticle/beam_utils.f90
+++ b/bmad/multiparticle/beam_utils.f90
@@ -46,7 +46,7 @@ real(rp) charge, ds_wake
 
 integer, optional :: direction
 integer i, j, n, jj
-logical err_flag, finished, thread_safe
+logical err_flag, finished, thread_safe, wake_here
 
 character(*), parameter :: r_name = 'track1_bunch_hom'
 
@@ -61,9 +61,21 @@ call save_a_bunch_step (ele, bunch, bunch_track, 0.0_rp)
 
 !------------------------------------------------
 ! Without wakefields just track through.
+! Note: An element may have a wake struct but still not apply any wake. This happens if the relevant
+! global on/off switch is set to False or if the wake has no active modes. In this case the expensive
+! wake path (which z-orders the particles and splits the element in two) must be avoided.
 
 wake_ele => pointer_to_wake_ele(ele, ds_wake)
-if (.not. associated (wake_ele) .or. (.not. bmad_com%sr_wakes_on .and. .not. bmad_com%lr_wakes_on)) then
+
+wake_here = .false.
+if (associated(wake_ele)) then
+  if (bmad_com%sr_wakes_on .and. (size(wake_ele%wake%sr%long) /= 0 .or. size(wake_ele%wake%sr%trans) /= 0 .or. &
+                                  size(wake_ele%wake%sr%z_long%w) /= 0)) wake_here = .true.
+  if (bmad_com%lr_wakes_on .and. size(wake_ele%wake%lr%mode) /= 0) wake_here = .true.
+  if (associated(track1_wake_hook_ptr) .and. (bmad_com%sr_wakes_on .or. bmad_com%lr_wakes_on)) wake_here = .true.
+endif
+
+if (.not. wake_here) then
 
   if (bmad_com%radiation_damping_on .or. bmad_com%radiation_fluctuations_on) call radiation_map_setup(ele, err_flag)
   !$OMP parallel do if (thread_safe)


### PR DESCRIPTION
## Summary

Beam tracking through elements that define a short-range (SR) wake was extremely slow (about 45 seconds for the example below) even when the SR wake calculation was explicitly disabled with `bmad_com[sr_wakes_on] = False`. Commenting out the `sr_wake` definition made the same run finish in about 2 seconds. This change fixes the underlying logic error so that a disabled wake no longer incurs the cost of the full wake-tracking path.

## Root cause

In `track1_bunch_hom` (`bmad/multiparticle/beam_utils.f90`), the guard that decided whether to take the fast straight-through tracking path or the expensive wake-tracking path was written as follows.

```fortran
wake_ele => pointer_to_wake_ele(ele, ds_wake)
if (.not. associated (wake_ele) .or. (.not. bmad_com%sr_wakes_on .and. .not. bmad_com%lr_wakes_on)) then
```

The long-range wake switch `bmad_com%lr_wakes_on` defaults to `True` (`bmad/modules/bmad_struct.f90`). Because the example element defines an `sr_wake`, the element's `wake` structure is associated and `pointer_to_wake_ele` returns the element. With `sr_wakes_on = False` but `lr_wakes_on = True`, the condition evaluated to `.false. .or. (.true. .and. .false.)`, which is `.false.`, so the code took the slow wake-tracking path even though no wake would actually be applied.

That slow path, executed for every wake element and for all one million particles, split the element and tracked the beam through it in two halves and then called `order_particles_in_z` to longitudinally sort the entire bunch. All of this work was wasted, because `track1_sr_wake` returns immediately when SR wakes are off and there were no long-range modes to apply. The guard tested only the global on/off switches and never checked whether any wake would in fact be applied.

## The fix

The guard now computes a `wake_here` flag from both the global switches and the element's actual wake content, so the expensive path is entered only when a wake will genuinely be applied. The existing behavior of the custom wake hook is preserved.

```fortran
wake_ele => pointer_to_wake_ele(ele, ds_wake)

wake_here = .false.
if (associated(wake_ele)) then
  if (bmad_com%sr_wakes_on .and. (size(wake_ele%wake%sr%long) /= 0 .or. size(wake_ele%wake%sr%trans) /= 0 .or. &
                                  size(wake_ele%wake%sr%z_long%w) /= 0)) wake_here = .true.
  if (bmad_com%lr_wakes_on .and. size(wake_ele%wake%lr%mode) /= 0) wake_here = .true.
  if (associated(track1_wake_hook_ptr) .and. (bmad_com%sr_wakes_on .or. bmad_com%lr_wakes_on)) wake_here = .true.
endif

if (.not. wake_here) then
```

## Files changed

- `bmad/multiparticle/beam_utils.f90`: Added the `wake_here` logical variable and replaced the fast-path guard so that it accounts for whether a wake will actually be applied.

## How to reproduce and verify

The following example lattice defines an SR wake on every element while disabling the SR wake calculation with `bmad_com[sr_wakes_on] = False`.

`lat.bmad`:

```
no_digested
BEGINNING[beta_a]  =  10
BEGINNING[beta_b]  = 10
parameter[geometry] = open
parameter[e_tot] = 42e6
bmad_com[sr_wakes_on] = F

P1: pipe, L = 0.06
P2:  Pipe, L = 0.07
P3: Pipe, L = 0.06

B1: SBEND, L = .133, b_field = .17
B2: SBEND, L = .122, b_field = -0.28

lat: line = (P1, B1, P2, B2, P3)   

! with bmad_com sr_wakes on = F this still makes the tracking slow:
*[sr_wake] = {z_scale=1, amp_scale=1, scale_with_length=True, z_max=100, longitudinal = {359502071447261.0, 21997.11131927352, 89168.95225455954, 0.25, none}}

use, lat
```

`tao.startup`:

```
set beam_init n_particle = 1000000
set beam_init bunch_charge = 100e-12
set beam_init sig_pz = 1e-9
set beam_init sig_z = 0.001
set beam_init a_norm_emit = 1e-6
set beam_init b_norm_emit = 1e-6

set global track_type = beam
quit
```

Run Tao against the lattice, which auto-loads `tao.startup` and tracks a beam of one million particles:

```
tao -lat lat.bmad -noplot
```

Before this change the run took about 45 seconds; after this change it takes about 2 seconds, matching the run time obtained by commenting out the `sr_wake` definition entirely.

## Acknowledgment

This bug was diagnosed and fixed with the assistance of GitHub Copilot, using the Claude Opus 4.8 model from Anthropic.
