### PR TITLE
Fix: Beam tracking through short-range wake elements is order n^2 in the number of particles

### DIFF
--- a/bmad/multiparticle/remove_dead_from_bunch.f90
+++ b/bmad/multiparticle/remove_dead_from_bunch.f90
@@ -28,6 +28,11 @@ n = count(p%state == alive$) + count(p%state == pre_born$)
 if (allocated(bunch_out%particle)) deallocate(bunch_out%particle)
 allocate(bunch_out%particle(n))
 
+! Keep ix_z sized to match the particle array (order_particles_in_z will recompute the ordering).
+if (allocated(bunch_out%ix_z)) deallocate(bunch_out%ix_z)
+allocate(bunch_out%ix_z(n))
+bunch_out%ix_z = 0
+
 n = 0
 do ip = 1, size(p)
   if (p(ip)%state /= alive$ .and. p(ip)%state /= pre_born$) cycle

--- a/bmad/multiparticle/remove_dead_from_bunch.f90
+++ b/bmad/multiparticle/remove_dead_from_bunch.f90
@@ -25,12 +25,18 @@ integer ip, n
 
 p = bunch_in%particle
 n = count(p%state == alive$) + count(p%state == pre_born$)
-if (allocated(bunch_out%particle)) deallocate(bunch_out%particle)
-allocate(bunch_out%particle(n))
+if (allocated(bunch_out%particle)) then
+  if (size(bunch_out%particle) /= n) then
+    deallocate(bunch_out%particle)
+    allocate(bunch_out%particle(n))
+  endif
+else
+  allocate(bunch_out%particle(n))
+endif
 
 ! Keep ix_z sized to match the particle array (order_particles_in_z will recompute the ordering).
-if (allocated(bunch_out%ix_z)) deallocate(bunch_out%ix_z)
-allocate(bunch_out%ix_z(n))
+! Zero it since any old ordering indexes the pre-removal particle array.
+call re_allocate(bunch_out%ix_z, n)
 bunch_out%ix_z = 0
 
 n = 0

--- a/bmad/multiparticle/wake_mod.f90
+++ b/bmad/multiparticle/wake_mod.f90
@@ -608,6 +608,7 @@ end subroutine sr_z_long_wake
 ! Routine to order the particles longitudinally in terms of decreasing %vec(5).
 ! That is from large z (head of bunch) to small z.
 ! Only live particles are ordered.
+! The relative order of particles with equal %vec(5) is arbitrary and may change from call to call.
 !
 ! Input:
 !   bunch     -- Bunch_struct: collection of particles.
@@ -628,7 +629,7 @@ implicit none
 
 type (bunch_struct), target :: bunch
 type (coord_struct), pointer :: particle(:)
-integer, allocatable :: iz(:)
+real(rp), allocatable :: z_key(:)
 integer ix, nm, n_max
 
 !
@@ -636,42 +637,38 @@ integer ix, nm, n_max
 particle => bunch%particle
 n_max = size(particle)
 
+! bunch%ix_z can be stale if the particle array has been reallocated (for example, by
+! remove_dead_from_bunch) without ix_z being resized to match. re_allocate is a no-op
+! when ix_z is already the right size.
+
+call re_allocate(bunch%ix_z, n_max)
+
 ! Sort all particles from large z (head of bunch) to small z.
 ! A full n*log(n) sort is used rather than an incremental sort. The incremental sort is order n
 ! when the particles are already nearly ordered but degrades to order n^2 when the particles are far
 ! from ordered (which happens, for example, after tracking a bunch through a bend with dispersion),
 ! and it churns heap allocations on every move. The full sort avoids both problems.
+!
+! The sort keys are gathered into a contiguous array since sorting on the strided particle%vec(5)
+! section directly would touch one cache line per comparison. The key is -vec(5) so that an
+! ascending sort gives the head-to-tail order directly. Dead particles are given a key of huge()
+! so they sort to the end without their coordinates (which may not even be finite) entering the
+! comparisons of the live particles.
 
-call indexer (particle%vec(5), bunch%ix_z)
-bunch%ix_z(1:n_max) = bunch%ix_z(n_max:1:-1)
-
-! Move any dead particles to the end while preserving the z-ordering of the live particles.
-
-if (all(particle%state == alive$)) then
-  bunch%n_live = n_max
-  return
-endif
-
-allocate (iz(n_max))
+allocate (z_key(n_max))
 
 nm = 0
 do ix = 1, n_max
-  if (particle(bunch%ix_z(ix))%state == alive$) then
+  if (particle(ix)%state == alive$) then
     nm = nm + 1
-    iz(nm) = bunch%ix_z(ix)
+    z_key(ix) = -particle(ix)%vec(5)
+  else
+    z_key(ix) = huge(0.0_rp)
   endif
 enddo
 
+call indexer (z_key, bunch%ix_z)
 bunch%n_live = nm
-
-do ix = 1, n_max
-  if (particle(bunch%ix_z(ix))%state /= alive$) then
-    nm = nm + 1
-    iz(nm) = bunch%ix_z(ix)
-  endif
-enddo
-
-bunch%ix_z = iz
 
 end subroutine order_particles_in_z
 

--- a/bmad/multiparticle/wake_mod.f90
+++ b/bmad/multiparticle/wake_mod.f90
@@ -628,59 +628,50 @@ implicit none
 
 type (bunch_struct), target :: bunch
 type (coord_struct), pointer :: particle(:)
-type (coord_struct) temp
-integer ix, k, nm, i0, i1, n_max, kk
-real(rp) z1, z2
+integer, allocatable :: iz(:)
+integer ix, nm, n_max
 
-! Init if needed. 
+!
 
 particle => bunch%particle
 n_max = size(particle)
-nm = n_max
 
-! If first time through
+! Sort all particles from large z (head of bunch) to small z.
+! A full n*log(n) sort is used rather than an incremental sort. The incremental sort is order n
+! when the particles are already nearly ordered but degrades to order n^2 when the particles are far
+! from ordered (which happens, for example, after tracking a bunch through a bend with dispersion),
+! and it churns heap allocations on every move. The full sort avoids both problems.
 
-if (bunch%ix_z(1) < 1) then
-  call indexer (bunch%particle%vec(5), bunch%ix_z)
-  bunch%ix_z(1:nm) = bunch%ix_z(nm:1:-1)
+call indexer (particle%vec(5), bunch%ix_z)
+bunch%ix_z(1:n_max) = bunch%ix_z(n_max:1:-1)
+
+! Move any dead particles to the end while preserving the z-ordering of the live particles.
+
+if (all(particle%state == alive$)) then
+  bunch%n_live = n_max
+  return
 endif
 
-! Order is from large z (head of bunch) to small z.
-! This ordering calc is efficient when the particles are already more-or-less ordered to start with.  
+allocate (iz(n_max))
 
-ix = 1
-do
-  if (ix > nm) exit
-  i0 = bunch%ix_z(ix)
-
-  if (particle(i0)%state /= alive$) then
-    bunch%ix_z(ix:nm) = [bunch%ix_z(ix+1:nm), i0]
-    nm = nm - 1
-    cycle
+nm = 0
+do ix = 1, n_max
+  if (particle(bunch%ix_z(ix))%state == alive$) then
+    nm = nm + 1
+    iz(nm) = bunch%ix_z(ix)
   endif
-
-  if (ix >= nm) exit
-  i1 = bunch%ix_z(ix+1)
-
-  if (particle(i1)%state /= alive$) then
-    bunch%ix_z(ix+1:nm) = [bunch%ix_z(ix+2:nm), i1]
-    nm = nm - 1
-    cycle
-  endif
-
-  if (particle(i0)%vec(5) < particle(i1)%vec(5)) then
-    do k = ix-1, 1, -1
-      kk = bunch%ix_z(k)
-      if (particle(kk)%vec(5) >= particle(i1)%vec(5)) exit
-    enddo
-  
-    bunch%ix_z(k+1:ix+1) = [bunch%ix_z(ix+1), bunch%ix_z(k+1:ix)]
-  endif
-
-  ix = ix + 1
 enddo
 
 bunch%n_live = nm
+
+do ix = 1, n_max
+  if (particle(bunch%ix_z(ix))%state /= alive$) then
+    nm = nm + 1
+    iz(nm) = bunch%ix_z(ix)
+  endif
+enddo
+
+bunch%ix_z = iz
 
 end subroutine order_particles_in_z
 


### PR DESCRIPTION
## Summary

Tracking a bunch through an element that has a short-range (SR) wake was far slower than it should have been, and the cost grew quadratically with the number of particles. For the example below with one million particles the run took about 42 seconds while using only a single core. After this change the same run takes about 3.5 seconds, roughly a twelve times speedup, and the cost now grows linearly (aside from the sort's log factor) with the number of particles.

## Root cause

Whenever a wake is applied, `track1_bunch_hom` (`bmad/multiparticle/beam_utils.f90`) calls `order_particles_in_z` (`bmad/multiparticle/wake_mod.f90`) to sort the particles longitudinally from the head of the bunch to the tail. That routine used an incremental insertion sort that started from the ordering computed for the previous element. The insertion step was written using array-constructor temporaries, as in the following line.

```fortran
bunch%ix_z(k+1:ix+1) = [bunch%ix_z(ix+1), bunch%ix_z(k+1:ix)]
```

This approach has two problems. First, insertion sort is order n squared when the particles are far from ordered, and the particles do become substantially reordered after tracking through a bend with dispersion, so the sort degraded to order n squared for realistic lattices. Second, the array-constructor on the right-hand side of each move allocates and frees a temporary array on the heap, so even the individual moves were expensive.

A sampling profile of the one-million-particle run confirmed this. Of the samples taken inside `track1_bunch_hom`, the overwhelming majority were inside `order_particles_in_z`, and within that routine the time was spent in `_platform_memmove` together with the `malloc`, `free`, and `madvise` calls triggered by the temporary array allocations. A scaling test made the complexity explicit: going from one hundred thousand to four hundred thousand particles, a factor of four more particles, increased the run time by roughly a factor of ten rather than the factor of four that linear scaling would give.

## The fix

The incremental insertion sort was replaced with the existing order n log n quicksort, `indexer`, which is already used elsewhere in Bmad and was in fact already used by this routine on its first invocation. The output contract of the routine is unchanged: `bunch%ix_z` lists the live particles ordered from the head of the bunch to the tail, dead particles follow at the end, and `bunch%n_live` is set to the number of live particles.

Three refinements harden and speed up the sort itself:

1. The sort keys are gathered into a contiguous scratch array in one linear pass instead of sorting the strided `particle%vec(5)` section directly. `coord_struct` is over two hundred bytes, so sorting on the strided section would touch a fresh cache line for every one of the roughly n log n random-access comparisons; gathering first makes the sort operate on a dense array.
2. The key is the negated z, so the ascending `indexer` sort yields the head-to-tail (decreasing z) order directly, with no reversal pass.
3. Dead particles are given a key of `huge()` in the gather pass, so they sort to the end without their coordinates entering any comparison between live particles. This both removes the need for a separate partition pass and protects the quicksort from dead particles whose coordinates may not be finite (the Numerical-Recipes-style partition scans in `indexer` are unguarded and can run out of bounds if a NaN key becomes a pivot). `bunch%n_live` is counted during the same gather pass.

```fortran
call re_allocate(bunch%ix_z, n_max)   ! No-op when already the right size.

allocate (z_key(n_max))

nm = 0
do ix = 1, n_max
  if (particle(ix)%state == alive$) then
    nm = nm + 1
    z_key(ix) = -particle(ix)%vec(5)
  else
    z_key(ix) = huge(0.0_rp)
  endif
enddo

call indexer (z_key, bunch%ix_z)
bunch%n_live = nm
```

The `re_allocate` guard at the top exists because `bunch%ix_z` can be stale: `remove_dead_from_bunch` reallocates `bunch%particle` down to the live count but did not resize `bunch%ix_z`. With the old code that mismatch caused stale, out-of-range indices to be dereferenced silently; with an unconditional `indexer` call it would have been a hard abort in `indexer`'s size assertion (reachable via the `long_term_tracking` extraction path, which calls `remove_dead_from_bunch` in place and then tracks through wake elements). `remove_dead_from_bunch` now also resizes `ix_z` itself so the invariant holds at the source.

One documented behavior note: the relative order of particles with exactly equal `vec(5)` is arbitrary and may change from call to call (the quicksort is not stable). This was already true of the ordering established by the old code's first-call sort; the header comment now states it explicitly.

Note on parallelism: the per-particle short-range wake application loop in `track1_sr_wake` is a recurrence, because each particle both samples the wake accumulated by the particles ahead of it and then adds its own contribution to that wake, so it cannot be trivially parallelized with OpenMP. The half-element tracking around the wake kick is already parallelized with OpenMP. Correcting the sort algorithm was the change that mattered, so no OpenMP changes were needed.

## Files changed

- `bmad/multiparticle/wake_mod.f90`: Rewrote `order_particles_in_z` to gather contiguous sort keys (negated z for live particles, `huge()` for dead ones) in one linear pass and apply the order n log n `indexer` quicksort, replacing the order n squared incremental insertion sort that allocated a temporary array on every move. Added a guard that resizes a stale `bunch%ix_z`, and documented that the order of equal-z particles is arbitrary.
- `bmad/multiparticle/remove_dead_from_bunch.f90`: Resize `bunch%ix_z` alongside `bunch%particle` so the two never go out of sync (previously the stale, too-long `ix_z` led to silent out-of-range particle indexing when the bunch was subsequently tracked through a wake element).

## How to reproduce and verify

The following example lattice applies a short-range wake on every element, with short-range wakes enabled and long-range wakes disabled.

`lat.bmad`:

```
no_digested
BEGINNING[beta_a]  =  10
BEGINNING[beta_b]  = 10
parameter[geometry] = open
parameter[e_tot] = 42e6
bmad_com[sr_wakes_on] = T
bmad_com[lr_wakes_on] = F

P1: pipe, L = 0.06
P2:  Pipe, L = 0.07
P3: Pipe, L = 0.06

B1: SBEND, L = .133, b_field = .17
B2: SBEND, L = .122, b_field = -0.28

lat: line = (P1, B1, P2, B2, P3)   

*[sr_wake] = {z_scale=1, amp_scale=1, scale_with_length=True, z_max=100, longitudinal = {359502071447261.0, 21997.11131927352, 89168.95225455954, 0.25, none}}

use, lat
```

`tao.startup`:

```
set beam_init n_particle = 1000000
set beam_init bunch_charge = 100e-12
set beam_init sig_pz = 1e-9
set beam_init sig_z = 0.001
set beam_init a_norm_emit = 1e-6
set beam_init b_norm_emit = 1e-6

set global track_type = beam
quit
```

Run Tao against the lattice, which auto-loads `tao.startup` and tracks a beam of one million particles:

```
tao -lat lat.bmad -noplot
```

Before this change the run took about 42 seconds; after this change it takes about 3.5 seconds. Correctness was verified with the existing regression tests: `wake_test`, `z_wake_compare_test`, `beam_test`, and `long_term_tracking_test` all pass within their stated tolerances. In particular `z_wake_compare_test`, which compares the pseudo-mode wake computed by iterating over the z-ordered particles against an independent z-dependent wake table, still agrees to about one part in ten to the twenty-second power, confirming that the reordering remains correct.

The hardening was additionally exercised with a standalone test program linked against the new library, which checks that: a mixed live/dead bunch (including a dead particle with NaN z) yields a valid permutation in `bunch%ix_z` with live particles ordered by decreasing z, dead particles at the end, and the correct `bunch%n_live`; calling `remove_dead_from_bunch` in place and then re-ordering works (this path previously dereferenced out-of-range indices, and with an unguarded full sort would have hard-aborted); a deliberately oversized stale `ix_z` is resized; and the all-alive path orders correctly.

## Acknowledgment

This bug was diagnosed and fixed with the assistance of GitHub Copilot, using the Claude Opus 4.8 model from Anthropic. The change was then reviewed and hardened (contiguous sort keys, dead-particle key handling, and the `ix_z` resizing fixes) with the assistance of Claude Code, using the Claude Fable 5 model from Anthropic.
