### PR TITLE
FIX: multi-universe 'set beam_init n@distribution_type(m)'

### DIFF
--- a/tao/code/tao_set_mod.f90
+++ b/tao/code/tao_set_mod.f90
@@ -1193,7 +1193,7 @@ if (is_real(value_str, real_num = r_val) .or. is_logical(value_str)) then
     write (iu, '(2a)') ' beam_init%' // trim(who2) // ' = ', trim(value_str)
   endif
 
-elseif (who(1:17) == 'distribution_type') then  ! Value is a vector so quote() function is not good here.
+elseif (who2(1:17) == 'distribution_type') then  ! Value is a vector so quote() function is not good here.
   vstr = value_str
   str = ''
   do i = 1, 3


### PR DESCRIPTION
## Background

`set beam_init ix_uni@distribution_type` does not work currently, because the check looks at the string with the universe rather than the one without.

In the current master branch:
```
Tao> set beam_init 2@distribution_type(1) = RAN_GAUSS
[ERROR | 2026-JUL-07 09:00:48] tao_evaluate_expression_new:
    Error parsing expression: Function: "RAN_GAUSS" is not followed by parenteses character "(" in: RAN_GAUSS
[ERROR | 2026-JUL-07 09:00:48] tao_evaluate_expression_new:
    Error parsing expression: Function: "RAN_GAUSS" is not followed by parenteses character "(" in: RAN_GAUSS
```

### After these changes

```
Tao> set beam_init 2@distribution_type(1) = RAN_GAUSS

Tao>
```