### PR TITLE
Performance tweaks for attribute bookkeeping

### DIFF
--- a/bmad/code/attribute_bookkeeper.f90
+++ b/bmad/code/attribute_bookkeeper.f90
@@ -57,6 +57,7 @@ type (converter_prob_pc_r_struct), pointer :: ppcr
 type (molecular_component_struct), allocatable :: component(:)
 type (material_struct), pointer :: material
 type (material_struct) :: materi
+type (ele_attribute_struct) ds_step_info
 
 real(rp) factor, e_factor, gc, f2, phase, E_tot, polarity, dval(num_ele_attrib$), time, beta
 real(rp) w_inv(3,3), len_old, f, dl, b_max, zmin, ky, kz, tot_mass
@@ -294,7 +295,8 @@ endif
 ! If the ref energy has not been set then, for example, k1 for a bend with field_master = T has not been set.
 ! So have to wait until the energy is set to figure out ds_step.
 
-if (attribute_index(ele, 'DS_STEP') > 0 .and. val(p0c$) > 0) then  ! If this is an attribute for this element...
+ds_step_info = attribute_info(ele, ds_step$)
+if (ds_step_info%state /= does_not_exist$ .and. val(p0c$) > 0) then  ! If this is an attribute for this element...
 
   dz_dl_max_err = 1d-8
 

--- a/bmad/modules/attribute_mod.f90
+++ b/bmad/modules/attribute_mod.f90
@@ -3098,7 +3098,7 @@ end function attribute_free1
 ! This function overloaded by attribute_free. See attribute_free for more details.
 !-
 
-function attribute_free2 (ele, attrib_name, err_print_flag, except_overlay, dependent_attribs_free, why_not_free) result (free)
+function attribute_free2 (ele, attrib_name, err_print_flag, except_overlay, dependent_attribs_free, why_not_free, ix_attrib) result (free)
 
 implicit none
 
@@ -3107,7 +3107,7 @@ type (ele_struct) ele
 
 character(*) attrib_name
 
-integer, optional :: why_not_free
+integer, optional :: why_not_free, ix_attrib
 
 logical free
 logical, optional :: err_print_flag, except_overlay, dependent_attribs_free
@@ -3123,7 +3123,8 @@ endif
 
 ! init & check
 
-free = check_this_attribute_free (ele, attrib_name, ele%branch%lat, err_print_flag, except_overlay, dependent_attribs_free, why_not_free)
+free = check_this_attribute_free (ele, attrib_name, ele%branch%lat, err_print_flag, except_overlay, &
+                                                             dependent_attribs_free, why_not_free, ix_attrib)
 
 end function attribute_free2
 
@@ -3164,7 +3165,7 @@ end function attribute_free3
 !--------------------------------------------------------------------------
 
 function check_this_attribute_free (ele, attrib_name, lat, err_print_flag, except_overlay, &
-                                                           dependent_attribs_free, why_not_free) result (free)
+                                                           dependent_attribs_free, why_not_free, ix_attrib_in) result (free)
 
 implicit none
 
@@ -3176,7 +3177,7 @@ type (ele_attribute_struct) attrib_info
 type (control_struct), pointer :: control
 type (all_pointer_struct) a_ptr
 
-integer, optional :: why_not_free
+integer, optional :: why_not_free, ix_attrib_in
 integer ix_branch, i, ir, ix_attrib, ix, ic, is, il
 
 character(*) attrib_name
@@ -3195,9 +3196,14 @@ dep_attribs_free = logic_option(.false., dependent_attribs_free)
 
 branch => lat%branch(ele%ix_branch)
 
-! Init & check that the name corresponds to an attribute
+! Init & check that the name corresponds to an attribute.
+! Callers in the bookkeeping hot path pass the already-resolved index to skip the name lookup.
 
-ix_attrib = attribute_index(ele, attrib_name)
+if (present(ix_attrib_in)) then
+  ix_attrib = ix_attrib_in
+else
+  ix_attrib = attribute_index(ele, attrib_name)
+endif
 attrib_info = attribute_info(ele, ix_attrib)
 
 a_name = attribute_name (ele, ix_attrib)

--- a/bmad/modules/bookkeeper_mod.f90
+++ b/bmad/modules/bookkeeper_mod.f90
@@ -1656,6 +1656,10 @@ do i = 1, slave%n_lord
   endif
 
   ! overlay lord
+  ! An off overlay contributes nothing (overlay_change_this returns immediately for it), so skip all
+  ! of its makeup work rather than resolve the attribute and then discard the result.
+
+  if (.not. lord%is_on) cycle
 
   select case (control%ix_attrib)
   case (x_limit$)

--- a/bmad/modules/bookkeeper_mod.f90
+++ b/bmad/modules/bookkeeper_mod.f90
@@ -44,14 +44,14 @@ if (.not. lord%is_on) return
 do i = 1, lord%n_slave
   slave => pointer_to_slave(lord, i, control)
   attrib_name = control%attribute
-  if (attrib_name == 'L') moved = .true.
+  if (control%ix_attrib == l$) moved = .true.
 
-  select case (attrib_name)
+  select case (control%ix_attrib)
 
   !---------
   ! Edge: Varying lengths takes special code.
 
-  case ('START_EDGE', 'END_EDGE', 'S_POSITION', 'ACCORDION_EDGE', 'L')
+  case (start_edge$, end_edge$, s_position$, accordion_edge$, l$)
 
     if (slave%lord_status == multipass_lord$) then
       do j = 1, slave%n_slave
@@ -65,15 +65,15 @@ do i = 1, lord%n_slave
   !---------
   ! x_limit, y_limit, aperture
 
-  case ('X_LIMIT')
+  case (x_limit$)
     call group_change_this (slave, 'X1_LIMIT', control, 1);  if (err_flag) return
     call group_change_this (slave, 'X2_LIMIT', control, 1);  if (err_flag) return
 
-  case ('Y_LIMIT')
+  case (y_limit$)
     call group_change_this (slave, 'Y1_LIMIT', control, 1);  if (err_flag) return
     call group_change_this (slave, 'Y2_LIMIT', control, 1);  if (err_flag) return
 
-  case ('APERTURE') 
+  case (aperture$)
     call group_change_this (slave, 'X1_LIMIT', control, 1);  if (err_flag) return
     call group_change_this (slave, 'X2_LIMIT', control, 1);  if (err_flag) return
     call group_change_this (slave, 'Y1_LIMIT', control, 1);  if (err_flag) return
@@ -1657,14 +1657,14 @@ do i = 1, slave%n_lord
 
   ! overlay lord
 
-  select case (control%attribute)
-  case ('X_LIMIT')
+  select case (control%ix_attrib)
+  case (x_limit$)
     call overlay_change_this(lord, slave%value(x1_limit$), control, val_attrib, ptr_attrib);  if (err_flag) return
     call overlay_change_this(lord, slave%value(x2_limit$), control, val_attrib, ptr_attrib);  if (err_flag) return
-  case ('Y_LIMIT')
+  case (y_limit$)
     call overlay_change_this(lord, slave%value(y1_limit$), control, val_attrib, ptr_attrib);  if (err_flag) return
     call overlay_change_this(lord, slave%value(y2_limit$), control, val_attrib, ptr_attrib);  if (err_flag) return
-  case ('APERTURE')
+  case (aperture$)
     call overlay_change_this(lord, slave%value(x1_limit$), control, val_attrib, ptr_attrib);  if (err_flag) return
     call overlay_change_this(lord, slave%value(x2_limit$), control, val_attrib, ptr_attrib);  if (err_flag) return
     call overlay_change_this(lord, slave%value(y1_limit$), control, val_attrib, ptr_attrib);  if (err_flag) return

--- a/bmad/modules/bookkeeper_mod.f90
+++ b/bmad/modules/bookkeeper_mod.f90
@@ -1670,7 +1670,7 @@ do i = 1, slave%n_lord
     call overlay_change_this(lord, slave%value(y1_limit$), control, val_attrib, ptr_attrib);  if (err_flag) return
     call overlay_change_this(lord, slave%value(y2_limit$), control, val_attrib, ptr_attrib);  if (err_flag) return
   case default
-    err_flag = .not. attribute_free (slave, control%attribute, .true., .true., .true.)
+    err_flag = .not. attribute_free (slave, control%attribute, .true., .true., .true., ix_attrib = control%ix_attrib)
     if (err_flag) then
       call out_io (s_abort$, r_name, 'OVERLAY LORD: ' // lord%name, &
            'IS TRYING TO VARY NON-FREE ATTRIBUTE: ' // trim(slave%name) // '[' // trim(control%attribute) // ']')

--- a/bmad/modules/bookkeeper_mod.f90
+++ b/bmad/modules/bookkeeper_mod.f90
@@ -1677,10 +1677,16 @@ do i = 1, slave%n_lord
       return
     endif
 
-    call pointer_to_attribute (slave, control%attribute, .true., a_ptr, err_flag, do_unlink = .true.)
-    if (err_flag) then
-      if (global_com%exit_on_error) call err_exit
-      return
+    ! Use the cached attribute index to avoid re-resolving control%attribute by name every bookkeep.
+    ! Only normal %value attributes take the fast path; the rest fall back to the name-based lookup.
+    if (control%ix_attrib > 0 .and. control%ix_attrib <= num_ele_attrib$) then
+      a_ptr%r => slave%value(control%ix_attrib)
+    else
+      call pointer_to_attribute (slave, control%attribute, .true., a_ptr, err_flag, do_unlink = .true.)
+      if (err_flag) then
+        if (global_com%exit_on_error) call err_exit
+        return
+      endif
     endif
     call overlay_change_this(lord, a_ptr%r, control, val_attrib, ptr_attrib)
   end select


### PR DESCRIPTION
## Background

I'm trying to update thousands of attributes across many elements programmatically and run the lattice bookkeeper.
Profiling a reasonably simple benchmark shows that:
* A very significant period of time is spent on string comparisons (`select case`, `attribute_index`)
* `attribute_free` calls end up taking a lot of time, even if I know ahead of time that the attribute is free
* Overlays that are off still run through a lot of attribute index checks unnecessarily (including a ton of string comparisons)

### Changes

This PR mainly addresses the string comparison bits.
* Instead of comparing attribute names, it changes over to attribute constants.
* `attribute_index` is avoided in a few hot spots
* It adds an `ix_attrib` input for `attribute_free` to avoid yet another string lookup of the attribute
* It avoids a single case of `pointer_to_attribute` when a "regular" attribute is found as it's a rather simple operation to update the all_pointer_struct
* It avoids further bookkeeping when an overlay is found to be off ([ee3ed21](https://github.com/bmad-sim/bmad-ecosystem/pull/2093/commits/ee3ed219480d3bcd157190b59dd9509f1c515297))