### PR TITLE
Fix bug using Fable as requested by Dave

### DIFF
--- a/forest/code/Sh_def_kind.f90
+++ b/forest/code/Sh_def_kind.f90
@@ -25158,7 +25158,7 @@ endif
         c%delta_rad_out=denf/2+c%delta_rad_out
        endif
 endif
-    call alloc(st)
+    call alloc(st,z)
 
     if(k%TIME) then
        ST=SQRT(1.0_dp+2.0_dp*X(5)/EL%P%beta0+x(5)**2)-1.0_dp
@@ -25207,8 +25207,6 @@ endif
           endif
        ELSEif(el%kind==kind22) then
 
-          call alloc(z)
-
           IF(EL%HE22%P%DIR==1) THEN
              Z= pos*el%l/el%p%nst
           ELSE
@@ -25226,7 +25224,6 @@ endif
              X(4)=(X(4)-EL%P%CHARGE*AV(2))*(1.0_dp+X(5))/(1.0_dp+ST)
              X(4)=X(4)+EL%P%CHARGE*AV(2)
           endif
-          call kill(av,3)
 
        ELSE
  if(k%TIME) then
@@ -25246,13 +25243,13 @@ endif
        ENDIF
     endif
 
-    call kill(st)
+    call kill(st,z)
+    call kill(av,3)
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     p%x=x
     call kill(x)
-           call kill(z)
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   end subroutine radiate_2_probep


### PR DESCRIPTION
Fixed. The crash was an alloc/kill imbalance in radiate_2_probep (forest/code/Sh_def_kind.f90) introduced by the PTC Pancake commit (1b8a10298); ptc_test now runs to completion in ~2 seconds.

What was happening. The "hang" wasn't a hang: PTC's DA package printed ERROR IN DAINF, DA VECTOR -20 NOT FOUND and then called mypause, which blocks reading stdin. An lldb backtrace (breakpoint on mypause) showed the failure inside ptc_setup_map_with_radiation → radiate_2_probep → powmap → daall1.

Root cause. The commit's rewrite of radiate_2_probep broke TPSA alloc/kill pairing across branches:
- z was killed unconditionally at the end but only alloc'd inside the kind22 branch. For the quads/bends/RF in tiny_ring.bmad, kill(z) ran on an uninitialized real_8, freeing a garbage DA index and corrupting the DA allocation table — the next allocation handed out the bogus index -20 and dainf aborted.
- av was alloc'd unconditionally but killed only in the kind22 branch (a 3-vector leak per call).

Fix (forest/code/Sh_def_kind.f90:25161): alloc z alongside st at the top and kill st, z and av unconditionally at the end, matching the pattern already used in radiate_2_forcep. Rebuilt with CondaCompile.bash; the new generalized_gradient_test from the same commit still passes bit-for-bit, so the pancake feature is unaffected.

One thing needs your judgment. ptc_test output no longer matches output.correct on a few lines, and this is not from my fix — the same commit intentionally rewrote the radiation recoil physics (the transverse kick is now applied via x′ with a curvature factor (1 + b0·x(1)) instead of simple momentum rescaling). Out of tolerance:
- layout-emit: a/b emittances changed from 4.64e-10 / 4.62e-10 to 8.68e-10 / 3.14e-10 (this tilt-coupled ring had near-equal emittances before; they now split substantially), z-emit shifted 0.5%.
- layout-damp (z, 0.5% on a near-zero value) and layout-sigma1 (marginal, 3e-12 vs 2e-12 tolerance).

Everything else agrees within tolerance. If the new radiation physics is expected (worth confirming with David/Étienne), output.correct should be regenerated; I left it untouched.