### PR TITLE
CI: version tag on release via GitHub App

### DIFF
--- a/.github/scripts/update_bmad_version.sh
+++ b/.github/scripts/update_bmad_version.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Usage: update_bmad_version.sh <version>
+#
+# Stamps bmad/modules/bmad_version_mod.f90 with the given version string.
+# Run by the release workflow so the reported version matches the release tag.
+
+set -euo pipefail
+
+VERSION="${1:?Usage: update_bmad_version.sh <version>}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+VERSION_FILE="$REPO_ROOT/bmad/modules/bmad_version_mod.f90"
+
+cat >"$VERSION_FILE" <<EOF
+!+
+! Module bmad_version_mod
+!
+! This file is generated automatically via a GitHub action. Do not modify by hand.
+!-
+
+module bmad_version_mod
+character(*), parameter :: bmad_version_date = "$VERSION"
+end module
+EOF
+
+echo "Stamped $VERSION_FILE with version $VERSION"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Bmad Ecosystem - Build & Test
 
+permissions:
+  contents: read
+
 on:
   # Run on demand, push, or pull request
   workflow_dispatch:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -1,5 +1,8 @@
 name: Bmad-ecosystem - Conda build & test
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:

--- a/.github/workflows/pytao.yml
+++ b/.github/workflows/pytao.yml
@@ -1,5 +1,8 @@
 name: PyTao tests
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,22 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     steps:
-      # Check out the code from GitHub and all history
+      # Mint a short-lived (1 hour) installation token from the release
+      # GitHub App. The App's private key never expires, so there is no
+      # token to rotate. The App must be installed on this repo and added
+      # to the `main` ruleset bypass list so it can push the release commit.
+      - name: Generate GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      # Check out the code from GitHub and all history, using the App token
+      # so the version-stamp commit below can be pushed back to main.
       - uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app_token.outputs.token }}
 
 
       - name: Define Release Name
@@ -35,6 +49,27 @@ jobs:
           # and set it as an output variable
           echo "Next version: $(.github/scripts/next_version.sh)"
           echo "version=$(.github/scripts/next_version.sh)" >> $GITHUB_OUTPUT
+
+      # Stamp the release version into the Fortran source and commit it to
+      # main so that the version Tao reports matches the release tag. This
+      # commit must land before the release/tag is created below so the
+      # tagged tree contains the correct version.
+      - name: Get GitHub App user id
+        id: app_user
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+        run: |
+          echo "id=$(gh api "/users/${{ steps.app_token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+
+      - name: Stamp Bmad version in Fortran code
+        run: |
+          VERSION="${{ steps.release_name.outputs.version }}"
+          .github/scripts/update_bmad_version.sh "$VERSION"
+          git config user.name "${{ steps.app_token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.app_user.outputs.id }}+${{ steps.app_token.outputs.app-slug }}[bot]@users.noreply.github.com"
+          git add bmad/modules/bmad_version_mod.f90
+          git commit -m "REL: $VERSION [skip ci]"
+          git push origin HEAD:main
 
     #   Uncomment this block if we decide to run the tests later
     #   # Install system dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           git config user.name "${{ steps.app_token.outputs.app-slug }}[bot]"
           git config user.email "${{ steps.app_user.outputs.id }}+${{ steps.app_token.outputs.app-slug }}[bot]@users.noreply.github.com"
           git add bmad/modules/bmad_version_mod.f90
-          git commit -m "REL: $VERSION [skip ci]"
+          git diff --cached --quiet || git commit -m "REL: $VERSION [skip ci]"
           git push origin HEAD:main
 
     #   Uncomment this block if we decide to run the tests later


### PR DESCRIPTION
## Background

Supersedes #2098. Goal: the version Tao reports should match the latest release tag (and hence the `conda install` version), and update automatically on release rather than only when a maintainer commits.

## Approach

Instead of a PAT (fine-grained PATs expire in 366 days or less; classic no-expiry PATs are a broad-scope liability), this uses a **GitHub App**:

* `release.yml` mints a short-lived installation token via `actions/create-github-app-token@v2`, checks out with it, then stamps the version and pushes a `REL: <version> [skip ci]` commit to `main` **before** the tag is created, so the tagged tree contains the correct version.
* The App's private key never expires, so there is nothing to rotate.
* `main` has been migrated from classic branch protection to a **ruleset**; the App is on the ruleset's bypass list, so it can push the release commit while everyone else still goes through PRs.

## Changes

* Add `.github/scripts/update_bmad_version.sh` which stamps `bmad/modules/bmad_version_mod.f90` (module `bmad_version_mod`, param `bmad_version_date`) with the release version. (The version module moved here from `tao/version/tao_version_mod.f90` in #2099.)
* `release.yml`: mint App token, check out with it, stamp + commit + push the version.
* `ci.yml`, `conda-build.yml`, `pytao.yml`: add `permissions: contents: read` (non-release workflows do not need write).

## Admin setup (done)

* GitHub App (App ID `4267935`) created under `bmad-sim`, Contents: read/write, installed on this repo.
* Repo variable `APP_ID` and secret `APP_PRIVATE_KEY` set.
* `main` ruleset created with the App in the bypass list; classic branch protection removed.

Note: the reported version format changes from a timestamp (`2026/07/10 14:30:00`) to the release-tag form (`20260710-0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
