### PR TITLE
Lux: interactive det_pix plotting and a working file combiner

### DIFF
--- a/lux/doc/lux.tex
+++ b/lux/doc/lux.tex
@@ -821,13 +821,13 @@ plots is illustrated in the Bmad manual in the \vn{Lattice Examples} chapter.
 
 %------------------------------------------------------------------
 
-There is a python script for making an intensity plot of the
-\vn{det_pix_out_file} in:
+There is a python script for plotting the \vn{det_pix_out_file} in:
 \begin{example}
   $ACC_ROOT_DIR/lux/scripts/plot_det_pix.py
 \end{example}
 
-The script needs python3 to run. You can invoke the script using the command:
+The script needs python3 along with the \vn{numpy} and \vn{matplotlib} packages. You can invoke the
+script using the command:
 \begin{example}
   <path-to-lux-root-dir>/scripts/plot_det_pix.py <det_pix_out_file>
 \end{example}
@@ -836,23 +836,54 @@ version of python is not python3 then the following may work
 \begin{example}
   python3 <path-to-lux-root-dir>/scripts/plot_det_pix.py <det_pix_out_file>
 \end{example}
+The associated \vn{.x}, \vn{.y} and \vn{.histogram} files may be given instead, in which case the
+script plots a curve rather than an image.
+
+The plot window is interactive so that the data can be explored without rerunning the script:
+\begin{example}
+  Quantity list    Plot any column of the file: intensity, e_ave, ang_x_ave, etc.
+  log scale        Switch between linear and logarithmic color scales.
+  equal aspect     Switch between a locked and a free aspect ratio.
+  cut at cursor    Clicking on the image plots horizontal and vertical lineouts
+                     through the point clicked on. When off, the side panels show
+                     the sum (or average) over all pixels.
+  colormap         Cycle through colormaps.
+\end{example}
+The keys \vn{n} and \vn{p} step through the quantities, \vn{l}, \vn{a}, \vn{m} and \vn{c} toggle the
+above settings, and \vn{?} prints the list of keys. Zooming, panning and saving the plot to a file
+are done with the standard \vn{matplotlib} toolbar. As the cursor is moved over the image, the
+toolbar shows the pixel under it along with its value.
+
+The colormap is chosen to suit the quantity being plotted: a sequential map for quantities like the
+intensity that do not change sign, a diverging map centered on zero for quantities like \vn{e_ave}
+that do, and a cyclic map for the phases. Pixels that are not in the data file are drawn in gray.
 
 The script has a number of optional arguments. The syntax for running the script is:
 \begin{example}
-  plot_det_pix.py \{-aspect <aspect_ratio>\} \{-scale <scale>\} 
-                                         \{-plot <who_to_plot>\} \{<data_file_name>\}
-  <who_to_plot> = x         # Intensity of x-polarized photons
-                = y         # Intensity of y-polarized photons
-                = i         # Total intensity (sum of x & y polarizations)
-                = e         # Energy
+  plot_det_pix.py \{-plot <column>\} \{-scale <scale>\} \{-aspect <aspect_ratio>\}
+                  \{-margin <n_pixel>\} \{-cmap <colormap>\} \{-log\} \{-list\}
+                  \{-save <file>\} \{-noshow\} \{-dpi <dpi>\} \{<data_file_name>\}
   Defaults:
-    <aspect_ratio>   = 1
+    <column>         = i
     <scale>          = 1e3
-    <data_file_name> = det_pix
-    <who_to_plot>    = i
+    <aspect_ratio>   = 1
+    <n_pixel>        = 4
+    <data_file_name> = det.pix
 \end{example}
 
-Figure~\ref{f:det.plot} shows two example intensity plots. 
+The \vn{<column>} argument is the name of any column in the data file. The name may be abbreviated
+as long as the abbreviation is unambiguous. For compatibility with older versions of the script, the
+following abbreviations are also accepted:
+\begin{example}
+  <column> = x         # Intensity of x-polarized photons
+           = y         # Intensity of y-polarized photons
+           = i         # Total intensity (sum of x & y polarizations)
+           = e         # Energy
+\end{example}
+Use \vn{-list} to print the header parameters and the list of columns of a data file without
+plotting anything.
+
+Figure~\ref{f:det.plot} shows two example intensity plots.
 
 The \vn{<scale>} parameter sets the scale of the axis numbers. A scale of \vn{1e3} results in the
 axis numbers being in millimeters.
@@ -861,6 +892,71 @@ The \vn{<aspect_ratio>} parameter sets the aspect ratio of the plot. An aspect r
 default) will mean that the vertical and horizontal scales (detector position per plotted unit
 length) begin the same. An aspect ratio greater than one will enlarge the vertical scale and less than
 one will enlarge the horizontal scale.
+
+The \vn{<n_pixel>} margin parameter sets the number of blank pixels drawn around the region of the
+detector that has data.
+
+The \vn{-save} argument writes the plot to a file. Combined with \vn{-noshow}, which suppresses the
+plot window, this can be used to generate plots from a script or on a machine without a display.
+
+%------------------------------------------------------------------
+\subsection{Plotting det_pix Data in Your Own Scripts}
+\label{s:det.pix.module}
+
+The reader that \vn{plot_det_pix.py} uses is a module of its own:
+\begin{example}
+  $ACC_ROOT_DIR/lux/scripts/det_pix.py
+\end{example}
+It can be used directly for custom plots and analysis. For example:
+\begin{example}
+  import sys
+  sys.path.append('<path-to-lux-root-dir>/scripts')
+  import det_pix
+
+  dp = det_pix.read('spherical.det_pix')
+  print(dp.params['n_track_tot'])        # Any header parameter.
+  print(dp.columns)                      # Names of the columns.
+  total = dp.col('intensity').sum()      # Any column, as a numpy array.
+
+  grid = dp.image('e_ave', scale = 1e3)  # Column mapped onto the pixel grid.
+  plt.imshow(grid.z, origin = 'lower', extent = grid.extent)
+\end{example}
+Column names are the ones in the data file, lowercased. Names in the \vn{Init} block, to the right
+of the vertical bar in the file, are prefixed with \vn{init_} so that, for example, \vn{ang_x_ave}
+and \vn{init_ang_x_ave} do not collide. The \vn{.x}, \vn{.y} and \vn{.histogram} files are read by
+the same routine. For these, use \vn{dp.curve(<column>)}, which returns the abscissa and the column
+as a pair of arrays.
+
+Running the module as a program prints a summary of a data file:
+\begin{example}
+  python3 <path-to-lux-root-dir>/scripts/det_pix.py <data_file_name>
+\end{example}
+
+%------------------------------------------------------------------
+\subsection{Combining det_pix Files from Multiple Runs}
+\label{s:combine}
+
+When a simulation has to be broken up into several runs, the resulting
+\vn{det_pix_out_files} can be merged into one with:
+\begin{example}
+  <path-to-lux-root-dir>/scripts/combine_det_pix_files.py <file1> <file2> ... \{-out <file>\}
+\end{example}
+The output, \vn{combined.det_pix} unless \vn{-out} says otherwise, is written in the same format
+Lux uses and so can be plotted or read like any other \vn{det_pix_out_file}.
+
+Note that the runs are not simply added up. The intensities Lux writes are normalized by the number
+of photons tracked (\sref{ss:master.params}), so each file is first put back on an unnormalized footing,
+the runs are summed, and the result is renormalized by the total number of photons tracked over all
+of the runs. Averages such as \vn{E_ave} and \vn{Ang_x_ave} are combined weighted by unnormalized
+intensity, which is how Lux forms them in the first place, and the rms values are combined through
+the second moments. Combining a file with itself therefore reproduces that file, apart from the
+photon counts.
+
+The runs must be of the same simulation: the script will stop if the files disagree on the pixel
+size, the normalization coefficient, or where the detector is. Also note that only pixels present in
+the input files can appear in the output, so
+\vn{lux_param%intensity_min_det_pixel_cutoff} must be set low enough in the runs being combined.
+Photon phases are not combined, so this script is not useful for coherent simulations.
 
 %------------------------------------------------------------------
 \subsection{Other plotting}

--- a/lux/scripts/combine_det_pix_files.py
+++ b/lux/scripts/combine_det_pix_files.py
@@ -1,211 +1,284 @@
 #!/usr/bin/env python3
 
-# Script to combine det_pix output files from Lux into one det_pix file.
-# This is useful when a simulation has to be broken up into multiple runs.
+"""
+Combine Lux det_pix files into one, for when a simulation has to be broken up
+into multiple runs.
 
+  combine_det_pix_files.py run1.det_pix run2.det_pix ... {-out <file>}
+
+The result is written in the same format Lux uses, so it can be fed to
+plot_det_pix.py or read with det_pix.py like any other det_pix file.
+
+What "combining" means here: the intensity Lux writes is normalized by the
+number of photons tracked (see lux_param%intensity_normalization_coef), so the
+runs are not simply added up. Each file is first put back on an unnormalized
+footing, the runs are summed, and the total is renormalized by the total number
+of photons tracked over all of the runs. Averages (E_ave, Ang_x_ave, ...) are
+combined weighted by unnormalized intensity, which is how Lux forms them in the
+first place, and the rms values are combined through the second moments.
+
+Only pixels that are in the input files can be in the output. Lux leaves out
+pixels below lux_param%intensity_min_det_pixel_cutoff, so set that low enough in
+the runs being combined.
+"""
+
+import os
 import sys
-import math
+import argparse
 
-T = True    # For converting from det_pix file header T/F notation
-F = False
+import numpy as np
 
-class pix_class:
-  def __init__(self):
-    self.x_pix          = 0
-    self.y_pix          = 0
-    self.intens_x       = 0
-    self.phase_x        = 0
-    self.intens_y       = 0
-    self.phase_y        = 0
-    self.intensity      = 0
-    self.n_photon       = 0
-    self.e_ave          = 0
-    self.e_rms          = 0
-    self.ang_x_ave      = 0
-    self.ang_x_rms      = 0
-    self.ang_y_ave      = 0
-    self.ang_y_rms      = 0
-    self.x_ave_init     = 0
-    self.x_rms_init     = 0
-    self.ang_x_ave_init = 0
-    self.ang_x_rms_init = 0
-    self.y_ave_init     = 0
-    self.y_rms_init     = 0
-    self.ang_y_ave_init = 0
-    self.ang_y_rms_init = 0
-  
-#----------------------------------------------
+import det_pix
 
-def ave(ave_old, intens_old, ave_now, intens_now):
-  ave_now = float(ave_now)
-  intens_now = float(intens_now)
-  return (ave_old * intens_old + ave_now * intens_now) / (intens_old + intens_now)
+# The (average, rms) column pairs. Both members of a pair are combined together
+# because the new rms depends on the old averages.
 
-#----------------------------------------------
+AVE_RMS = [('e_ave', 'e_rms'),
+           ('ang_x_ave', 'ang_x_rms'),
+           ('ang_y_ave', 'ang_y_rms'),
+           ('init_x_ave', 'init_x_rms'),
+           ('init_ang_x_ave', 'init_ang_x_rms'),
+           ('init_y_ave', 'init_y_rms'),
+           ('init_ang_y_ave', 'init_ang_y_rms')]
 
-def rms(rms_old, ave_old, intens_old, rms_now, ave_now, intens_now):
-  rms_now = float(rms_now)
-  ave_now = float(ave_now)
-  intens_now = float(intens_now)
+# Runs that disagree on any of these are not measuring the same thing.
 
-  rms2_old = rms_old**2 + ave_old**2
-  rms2_now = rms_now**2 + ave_now**2
-  rms2_new = (rms2_old * intens_old + rms2_now * intens_now) / (intens_old + intens_now)
-  ave_new = (ave_old * intens_old + ave_now * intens_now) / (intens_old + intens_now)
-  return math.sqrt(max(0.0, rms2_new - ave_new**2))
+MUST_MATCH = ['intensity_normalization_coef', 'normalization_includes_pixel_area',
+              'dx_pixel', 'dy_pixel']
 
-#----------------------------------------------
+# Header parameters this script knows about. Anything else in a header comes
+# from lux_param%bmad_parameters_out and is passed through.
 
-pix_table = {}
+KNOWN = MUST_MATCH + ['master_parameter_file', 'lattice_file', 'normalization',
+                      'intensity_x_unnorm', 'intensity_x_norm', 'intensity_y_unnorm',
+                      'intensity_y_norm', 'intensity_unnorm', 'intensity_norm',
+                      'n_track_tot', 'n_at_detec', 'n_hit_pixel',
+                      'nx_active_min', 'nx_active_max', 'ny_active_min', 'ny_active_max',
+                      'x_center_det', 'y_center_det', 'x_rms_det', 'y_rms_det']
 
-for arg in sys.argv[1:]:
-  det_file = open(arg, 'r')
+#------------------------------------------------------------------------------
 
-  for n_header in range(1, 1000):
-    line = det_file.readline()
-    if line[0:3] == '#--': break
-    exec (line)              # This defines photons_tracked, etc. Look at a det_pix file to understand this.
-    if arg == sys.argv[1]:   # If first time.
-      z = line.split('=')
-      exec (z[0].strip() + '_tot =' +  z[1])  # This initalizes photons_tracked_tot, etc.
+def moments(ave, rms, weight):
+  """Combine averages and rms values of several samples into one (ave, rms).
 
-  if arg != sys.argv[1]:
-    master_parameter_file_tot  = master_parameter_file_tot + ', ' + master_parameter_file
-    lattice_file_tot           = lattice_file_tot + ', ' + lattice_file
-    photons_tracked_tot        = photons_tracked_tot + photons_tracked
-    nx_active_min_tot = min(nx_active_min_tot, nx_active_min)
-    nx_active_max_tot = max(nx_active_max_tot, nx_active_max)
-    ny_active_min_tot = min(ny_active_min_tot, ny_active_min)
-    ny_active_max_tot = max(ny_active_max_tot, ny_active_max)
-    intensity_x_unnorm_tot = intensity_x_unnorm_tot + intensity_x_unnorm
-    intensity_y_unnorm_tot = intensity_y_unnorm_tot + intensity_y_unnorm
+  Arrays may have an extra leading axis, in which case the combination is over
+  the first axis and the result is an array.
+  """
+  ave, rms, weight = np.asarray(ave), np.asarray(rms), np.asarray(weight)
+  total = weight.sum(axis = 0)
+  bad = (total == 0)
+  total = np.where(bad, 1.0, total)                 # Avoid 0/0 for empty pixels.
 
-    intensity_unnorm_old   = intensity_unnorm_tot
-    intensity_unnorm_tot   = intensity_unnorm_tot + intensity_unnorm
+  new_ave = (ave * weight).sum(axis = 0) / total
+  mean_sq = ((rms**2 + ave**2) * weight).sum(axis = 0) / total
+  new_rms = np.sqrt(np.maximum(0.0, mean_sq - new_ave**2))
+  return np.where(bad, 0.0, new_ave), np.where(bad, 0.0, new_rms)
 
-    normilization_tot    = normalization * photons_tracked / photons_tracked_tot
-    intensity_x_norm_tot = intensity_x_unnorm_tot * normalization_tot
-    intensity_y_norm_tot = intensity_y_norm_tot + intensity_y_norm * normalization_tot
-    intensity_norm_tot   = intensity_norm_tot + intensity_norm * normalization_tot
-    x_rms_det            = rms(x_rms_det_tot, x_center_det_tot, intensity_unnorm_old, x_rms_det, x_center_det, intensity_unnorm)
-    y_rms_det            = rms(y_rms_det_tot, y_center_det_tot, intensity_unnorm_old, y_rms_det, y_center_det, intensity_unnorm)
-    x_center_det_tot     = ave(x_center_det_tot, intensity_unnorm_old, x_center_det, intensity_unnorm)
-    y_center_det_tot     = ave(y_center_det_tot, intensity_unnorm_old, y_center_det, intensity_unnorm)
+#------------------------------------------------------------------------------
 
-  #----------------------------
+def check_input(dps):
+  """Complain about anything that makes the files uncombinable."""
 
-  while line:
-    line = det_file.readline()
-    if not line: break
-    if line[0] == '#': continue
-    col = line.rstrip().split()
-    pos = (col[0], col[1])
-    if not pos in pix_table: pix_table[pos] = pix_class()
-    pix = pix_table[pos]
-    pix.x_pix          = col[2]
-    pix.y_pix          = col[3]
-    pix.intens_x       = pix.intens_x + float(col[4])
-    pix.phase_x        = pix.phase_x
-    pix.intens_y       = pix.intens_y + float(col[6])
-    pix.phase_y        = pix.phase_y
+  for dp in dps:
+    if not dp.is_2d:
+      sys.exit('Not a det_pix file (the .x, .y and .histogram files cannot be '
+               'combined): ' + dp.file_name)
+    for key in MUST_MATCH + ['normalization', 'n_track_tot']:
+      if key not in dp.params:
+        sys.exit('Header parameter "%s" is missing from: %s' % (key, dp.file_name))
 
-    intensity_old = pix.intensity
-    pix.intensity      = pix.intensity + float(col[8])
+  first = dps[0]
+  for dp in dps[1:]:
+    for key in MUST_MATCH:
+      if dp.params[key] != first.params[key]:
+        sys.exit('Files disagree on %s: %s in %s but %s in %s' %
+                 (key, first.params[key], first.file_name, dp.params[key], dp.file_name))
 
-    pix.n_photon       = pix.n_photon + int(col[9])
-    pix.e_rms          = rms(pix.e_rms, pix.e_ave, intensity_old, col[11], col[10], col[8])
-    pix.e_ave          = ave (pix.e_ave, intensity_old, col[10], col[8])
+  if any(np.any(dp.col('phase_x')) or np.any(dp.col('phase_y')) for dp in dps):
+    print('WARNING: the input has non-zero phases, so it is from a coherent\n'
+          '         simulation. The runs are being added incoherently and the\n'
+          '         phases are dropped from the output.', file = sys.stderr)
 
-    pix.ang_x_rms      = rms(pix.ang_x_rms, pix.ang_x_ave, intensity_old, col[13], col[12], col[8])
-    pix.ang_x_ave      = ave(pix.ang_x_ave, intensity_old, col[12], col[8])
+#------------------------------------------------------------------------------
 
-    pix.ang_y_rms      = rms(pix.ang_x_rms, pix.ang_x_ave, intensity_old, col[15], col[14], col[8])
-    pix.ang_y_ave      = ave(pix.ang_x_ave, intensity_old, col[14], col[8])
+def combine(dps):
+  """Merge the pixel data of several files. Returns (pixels, params)."""
 
-    pix.x_rms_init     = rms(pix.x_rms_init, pix.x_ave_init, intensity_old, col[17], col[16], col[8])
-    pix.x_ave_init     = ave(pix.x_ave_init, intensity_old, col[16], col[8])
-    pix.ang_x_rms_init = rms(pix.ang_x_rms_init, pix.ang_x_ave_init, intensity_old, col[19], col[18], col[8])
-    pix.ang_x_ave_init = ave(pix.ang_x_ave_init, intensity_old, col[18], col[8])
+  # Every pixel that appears in any of the files, in the order Lux writes them.
 
-    pix.y_rms_init     = rms(pix.y_rms_init, pix.y_ave_init, intensity_old, col[21], col[20], col[8])
-    pix.y_ave_init     = ave(pix.y_ave_init, intensity_old, col[20], col[8])
-    pix.ang_y_rms_init = rms(pix.ang_y_rms_init, pix.ang_y_ave_init, intensity_old, col[23], col[22], col[8])
-    pix.ang_y_ave_init = ave(pix.ang_y_ave_init, intensity_old, col[22], col[8])
+  keys = sorted(set().union(*[set(zip(dp.col('ix').astype(int).tolist(),
+                                      dp.col('iy').astype(int).tolist())) for dp in dps]))
+  where = {key: n for n, key in enumerate(keys)}
+  n_pix, n_file = len(keys), len(dps)
 
-  det_file.close()
+  intens_x = np.zeros(n_pix)
+  intens_y = np.zeros(n_pix)
+  intensity = np.zeros(n_pix)
+  n_photon = np.zeros(n_pix, dtype = np.int64)
+  x_pix, y_pix = np.zeros(n_pix), np.zeros(n_pix)
 
-#----------------------------
+  # Averages are combined all at once at the end, so keep the per-file values.
 
-def to_str (str, fmt):
-  fmt = '{:' + fmt + '}'
-  if 'd' in fmt:
-    return fmt.format(int(str))
-  else:
-    return fmt.format(float(str))
+  ave = np.zeros((n_file, len(AVE_RMS), n_pix))
+  rms = np.zeros((n_file, len(AVE_RMS), n_pix))
+  weight = np.zeros((n_file, 1, n_pix))
+  filled = np.zeros(n_pix, dtype = bool)
 
-#----------------------------
+  dx = dps[0].params['dx_pixel']
+  dy = dps[0].params['dy_pixel']
 
-# key is [ix_pix, iy_pix] 
-def sort_order(key):
-  return 100000*int(key[0]) + int(key[1])
+  for n, dp in enumerate(dps):
+    norm = dp.params['normalization']       # Undo it: the runs are different sizes.
+    at = np.array([where[k] for k in zip(dp.col('ix').astype(int).tolist(),
+                                         dp.col('iy').astype(int).tolist())])
+    w = dp.col('intensity') / norm
 
-#----------------------------
+    # A pixel index has to mean the same place on the detector in every file.
+    off = filled[at] & ((np.abs(x_pix[at] - dp.col('x_pix')) > 0.01 * dx) |
+                        (np.abs(y_pix[at] - dp.col('y_pix')) > 0.01 * dy))
+    if off.any():
+      sys.exit('The detector is not in the same place in every file. Pixel %s is at '
+               '(%g, %g) in %s but elsewhere in another file.' %
+               (keys[at[off][0]], dp.col('x_pix')[off][0], dp.col('y_pix')[off][0], dp.file_name))
 
-out_file = open('dp.dat', 'w')
+    np.add.at(intens_x,  at, dp.col('intens_x') / norm)
+    np.add.at(intens_y,  at, dp.col('intens_y') / norm)
+    np.add.at(intensity, at, w)
+    np.add.at(n_photon,  at, dp.col('n_photon').astype(np.int64))
+    x_pix[at], y_pix[at] = dp.col('x_pix'), dp.col('y_pix')
+    filled[at] = True
+    weight[n, 0, at] = w
+    for m, (a, r) in enumerate(AVE_RMS):
+      ave[n, m, at], rms[n, m, at] = dp.col(a), dp.col(r)
 
-out_file.write('master_parameter_file             = "[' + master_parameter_file_tot + ']"\n')
-out_file.write('lattice_file                      = "[' + lattice_file_tot + ']"\n')
-out_file.write('intensity_normalization_coef      = ' + to_str(intensity_normalization_coef_tot, '.6g') + '\n')
-out_file.write('normalization_includes_pixel_area = ' + to_str(normalization_includes_pixel_area_tot, '.6g') + '\n')
-out_file.write('normalization       = ' + to_str(normalization_tot, '.6g') + '\n')
-out_file.write('intensity_x_unnorm  = ' + to_str(intensity_x_unnorm_tot, '.6g') + '\n')
-out_file.write('intensity_x_norm    = ' + to_str(intensity_x_norm_tot, '.6g') + '\n')
-out_file.write('intensity_y_unnorm  = ' + to_str(intensity_y_unnorm_tot, '.6g') + '\n')
-out_file.write('intensity_y_norm    = ' + to_str(intensity_y_norm_tot, '.6g') + '\n')
-out_file.write('intensity_unnorm    = ' + to_str(intensity_unnorm_tot, '.6g') + '\n')
-out_file.write('intensity_norm      = ' + to_str(intensity_norm_tot, '.6g') + '\n')
-out_file.write('dx_pixel            = ' + to_str(dx_pixel_tot, '.6g') + '\n')
-out_file.write('dy_pixel            = ' + to_str(dy_pixel_tot, '.6g') + '\n')
-out_file.write('nx_active_min       = ' + to_str(nx_active_min_tot, '.6g') + '\n')
-out_file.write('nx_active_max       = ' + to_str(nx_active_max_tot, '.6g') + '\n')
-out_file.write('ny_active_min       = ' + to_str(ny_active_min_tot, '.6g') + '\n')
-out_file.write('ny_active_max       = ' + to_str(ny_active_max_tot, '.6g') + '\n')
-out_file.write('x_center_det        = ' + to_str(x_center_det_tot, '.6g') + '\n')
-out_file.write('y_center_det        = ' + to_str(y_center_det_tot, '.6g') + '\n')
-out_file.write('x_rms_det           = ' + to_str(x_rms_det_tot, '.6g') + '\n')
-out_file.write('y_rms_det           = ' + to_str(y_rms_det_tot, '.6g') + '\n')
+  ave, rms = moments(ave, rms, weight)
 
-out_file.write('''
-#-----------------------------------------------------
-#                                                                                                                                                                    |                                          Init
-#   ix    iy      x_pix      y_pix   Intens_x    Phase_x   Intens_y    Phase_y  Intensity    N_photon     E_ave     E_rms  Ang_x_ave  Ang_x_rms  Ang_y_ave  Ang_y_rms|     X_ave      X_rms  Ang_x_ave  Ang_x_rms      Y_ave      Y_rms  Ang_y_ave  Ang_y_rms
-''')
+  #--------------------------------------------------------------------
+  # Header parameters. The detector-wide numbers are combined from the header
+  # values of the individual runs, weighted by their total intensity.
 
-for k in sorted(pix_table.keys(), key = sort_order):
-  p = pix_table[k]
-  out_file.write(to_str(k[0], '6d') +  
-                 to_str(k[1], '6d') +  
-                 to_str(p.x_pix, '11.3e') + 
-                 to_str(p.y_pix, '11.3e') + 
-                 to_str(p.intens_x, '11.3e') + 
-                 to_str(p.phase_x, '11.3e') + 
-                 to_str(p.intens_y, '11.3e') + 
-                 to_str(p.phase_y, '11.3e') + 
-                 to_str(p.intensity, '11.3e') + 
-                 to_str(p.n_photon, '12d') + 
-                 to_str(p.e_ave, '10.3f') + 
-                 to_str(p.e_rms, '10.3f') + 
-                 to_str(p.ang_x_ave, '11.3e') + 
-                 to_str(p.ang_x_rms, '11.3e') + 
-                 to_str(p.ang_y_ave, '11.3e') + 
-                 to_str(p.ang_y_rms, '11.3e') + 
-                 to_str(p.x_ave_init, '11.3e') + 
-                 to_str(p.x_rms_init, '11.3e') + 
-                 to_str(p.ang_x_ave_init, '11.3e') + 
-                 to_str(p.ang_x_rms_init, '11.3e') + 
-                 to_str(p.y_ave_init, '11.3e') + 
-                 to_str(p.y_rms_init, '11.3e') + 
-                 to_str(p.ang_y_ave_init, '11.3e') + 
-                 to_str(p.ang_y_rms_init, '11.3e') + '\n')
+  first = dps[0]
+  n_track = sum(dp.params['n_track_tot'] for dp in dps)
+  norm_tot = first.params['normalization'] * first.params['n_track_tot'] / n_track
+  w_file = [dp.params.get('intensity_unnorm', 0.0) for dp in dps]
 
-print ('Wrote: ' + out_file.name)
+  params = {}
+  for key in ('master_parameter_file', 'lattice_file'):
+    names = [str(dp.params.get(key, '?')) for dp in dps]
+    params[key] = names[0] if len(set(names)) == 1 else '[' + ', '.join(names) + ']'
+
+  for key in MUST_MATCH: params[key] = first.params[key]
+  params['normalization'] = norm_tot
+
+  for key in ('intensity_x_unnorm', 'intensity_y_unnorm', 'intensity_unnorm'):
+    params[key] = sum(dp.params.get(key, 0.0) for dp in dps)
+    params[key.replace('unnorm', 'norm')] = params[key] * norm_tot
+
+  for key in ('n_track_tot', 'n_at_detec', 'n_hit_pixel'):
+    params[key] = sum(dp.params.get(key, 0) for dp in dps)
+
+  for key in ('nx_active_min', 'ny_active_min'):
+    params[key] = min(dp.params[key] for dp in dps if key in dp.params)
+  for key in ('nx_active_max', 'ny_active_max'):
+    params[key] = max(dp.params[key] for dp in dps if key in dp.params)
+
+  for axis in 'xy':
+    center, spread = moments([dp.params.get('%s_center_det' % axis, 0.0) for dp in dps],
+                             [dp.params.get('%s_rms_det' % axis, 0.0) for dp in dps], w_file)
+    params['%s_center_det' % axis] = float(center)
+    params['%s_rms_det' % axis] = float(spread)
+
+  # Whatever lux_param%bmad_parameters_out put in the header.
+
+  for key in first.params:
+    if key in KNOWN: continue
+    values = [dp.params.get(key) for dp in dps]
+    params[key] = values[0] if len(set(values)) == 1 else 'CONFLICTING VALUES'
+
+  pixels = dict(keys = keys, x_pix = x_pix, y_pix = y_pix, intens_x = intens_x,
+                intens_y = intens_y, intensity = intensity, n_photon = n_photon,
+                ave = ave, rms = rms)
+  return pixels, params
+
+#------------------------------------------------------------------------------
+
+def write(file_name, pixels, params, extra_keys):
+  """Write the combined data in the format Lux itself uses."""
+
+  norm = params['normalization']
+  dx, dy = params['dx_pixel'], params['dy_pixel']
+
+  with open(file_name, 'w') as f:
+    f.write('# master_parameter_file             = "%s"\n' % params['master_parameter_file'])
+    f.write('# lattice_file                      = "%s"\n' % params['lattice_file'])
+    f.write('# intensity_normalization_coef      = %12.4E\n' % params['intensity_normalization_coef'])
+    f.write('# normalization_includes_pixel_area = %2s\n' %
+            ('T' if params['normalization_includes_pixel_area'] else 'F'))
+    f.write('# normalization       = %14.6E\n' % norm)
+    for key in ('intensity_x_unnorm', 'intensity_x_norm', 'intensity_y_unnorm',
+                'intensity_y_norm', 'intensity_unnorm', 'intensity_norm'):
+      f.write('# %-19s = %16.5E\n' % (key, params[key]))
+    for key in ('n_track_tot', 'n_at_detec', 'n_hit_pixel'):
+      f.write('# %-19s = %d\n' % (key, params[key]))
+    f.write('# dx_pixel            = %10.6f\n' % dx)
+    f.write('# dy_pixel            = %10.6f\n' % dy)
+    for key in ('nx_active_min', 'nx_active_max', 'ny_active_min', 'ny_active_max'):
+      f.write('# %-19s = %8d\n' % (key, params[key]))
+
+    for key in extra_keys:                      # From lux_param%bmad_parameters_out.
+      value = params[key]
+      f.write('%s = %16.8E\n' % (key, value) if isinstance(value, float)
+              else '%s = "%s"\n' % (key, value))
+
+    for what in ('center', 'rms'):
+      for axis, d in (('x', dx), ('y', dy)):
+        key = '%s_%s_det' % (axis, what)
+        f.write('# %-19s =%16.5E  # %.4g pixels\n' % (key, params[key], params[key] / d))
+
+    f.write('#-----------------------------------------------------\n')
+    f.write('%s|%s\n' % ('#'.ljust(165), 'Init'.rjust(46)))
+    f.write('#   ix    iy      x_pix      y_pix   Intens_x    Phase_x   Intens_y    Phase_y'
+            '  Intensity    N_photon     E_ave     E_rms  Ang_x_ave  Ang_x_rms  Ang_y_ave'
+            '  Ang_y_rms|     X_ave      X_rms  Ang_x_ave  Ang_x_rms      Y_ave      Y_rms'
+            '  Ang_y_ave  Ang_y_rms\n')
+
+    for n, (ix, iy) in enumerate(pixels['keys']):
+      row = [pixels['x_pix'][n], pixels['y_pix'][n],
+             pixels['intens_x'][n] * norm, 0.0, pixels['intens_y'][n] * norm, 0.0,
+             pixels['intensity'][n] * norm]
+      f.write('%6d%6d%s%12d%s%s\n' % (ix, iy,
+              ''.join(('%11.3E' % v) for v in row), pixels['n_photon'][n],
+              ''.join(('%10.3f' % pixels[w][0,n]) for w in ('ave', 'rms')),
+              ''.join(('%11.3E' % pixels[w][m,n]) for m in range(1, len(AVE_RMS))
+                                                  for w in ('ave', 'rms'))))
+
+#------------------------------------------------------------------------------
+
+def main():
+  p = argparse.ArgumentParser(description = 'Combine Lux det_pix files into one.')
+  p.add_argument('files', nargs = '+', metavar = 'FILE', help = 'det_pix files to combine')
+  p.add_argument('-out', '--out', metavar = 'FILE', default = 'combined.det_pix',
+                 help = 'Output file. Default: combined.det_pix')
+  args = p.parse_args()
+
+  try:
+    dps = [det_pix.read(name) for name in args.files]
+  except (OSError, det_pix.DetPixError) as err:
+    sys.exit('%s' % err)
+
+  if os.path.abspath(args.out) in [os.path.abspath(f) for f in args.files]:
+    sys.exit('The output file is also one of the input files: ' + args.out)
+
+  check_input(dps)
+  pixels, params = combine(dps)
+  extra_keys = [key for key in params if key not in KNOWN]
+  write(args.out, pixels, params, extra_keys)
+
+  print('Combined %d file%s: %d photons tracked, %d pixels with data.' %
+        (len(dps), '' if len(dps) == 1 else 's', params['n_track_tot'], len(pixels['keys'])))
+  print('Wrote: ' + args.out)
+
+#------------------------------------------------------------------------------
+
+if __name__ == '__main__':
+  main()

--- a/lux/scripts/det_pix.py
+++ b/lux/scripts/det_pix.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+
+"""
+Reader for the data files written by Lux: det_pix_out_file and the associated
+".x", ".y" and ".histogram" files. All four share the same layout:
+
+  # <param> = <value>          Header parameters.
+  ...
+  #---------------------       Separator.
+  # ... banner ...             Zero or more banner lines.
+  #   ix    iy   x_pix  ...    Column names (last comment line).
+  <numbers>                    Data rows.
+
+Nothing here plots anything -- see plot_det_pix.py for that. This module is
+meant to be usable on its own:
+
+  >>> from det_pix import read
+  >>> dp = read('spherical.det_pix')
+  >>> dp.params['n_track_tot']
+  1000000
+  >>> dp.columns
+  ['ix', 'iy', 'x_pix', ..., 'init_ang_y_rms']
+  >>> dp.col('intensity').sum()
+  2.409e+08
+  >>> g = dp.image('intensity', scale = 1e3)   # 2D grid in mm
+  >>> plt.imshow(g.z, extent = g.extent, origin = 'lower')
+
+Column names are taken from the file itself and lowercased. Names to the right
+of the "|" in the header (the "Init" block) are prefixed with "init_" so that,
+for example, the initial and final Ang_x_ave columns do not collide.
+"""
+
+import os
+import re
+import numpy as np
+
+# Short names accepted anywhere a column name is wanted. The single letters are
+# the -plot arguments used by older versions of plot_det_pix.py.
+
+ALIASES = {
+  'x': 'intens_x',
+  'y': 'intens_y',
+  'i': 'intensity',
+  'e': 'e_ave',
+  'n': 'n_photon',
+  'intens': 'intensity',
+  'energy': 'e_ave',
+}
+
+# Columns that add up over pixels (as opposed to averages). Empty pixels are
+# zero for these and undefined (NaN) for everything else.
+
+_EXTENSIVE = ('intensity', 'intens_x', 'intens_y', 'n_photon')
+
+_SEPARATOR = re.compile(r'^\s*#?\s*-{3,}\s*$')
+_PARAM     = re.compile(r'^\s*#?\s*([A-Za-z_]\w*)\s*=\s*(.*)$')
+
+#------------------------------------------------------------------------------
+
+class DetPixError(Exception):
+  pass
+
+#------------------------------------------------------------------------------
+
+class Grid:
+  """A column mapped onto the detector pixel grid.
+
+  z          -- 2D array indexed [iy, ix], ready for imshow(origin = 'lower').
+  x, y       -- 1D arrays of pixel center coordinates.
+  extent     -- (x_min, x_max, y_min, y_max) of the pixel *edges*, for imshow.
+  dx, dy     -- Pixel size.
+  ix0, iy0   -- Pixel index of z[0,0]. So z[iy,ix] is pixel (ix+ix0, iy+iy0).
+  name       -- Name of the plotted column.
+  """
+
+  def __init__(self, z, x, y, dx, dy, ix0, iy0, name):
+    self.z, self.x, self.y = z, x, y
+    self.dx, self.dy = dx, dy
+    self.ix0, self.iy0 = ix0, iy0
+    self.name = name
+    self.extent = (x[0] - dx/2, x[-1] + dx/2, y[0] - dy/2, y[-1] + dy/2)
+
+  def index_at(self, x, y):
+    """Array indices (iy, ix) of the pixel containing point (x, y), or None."""
+    ix = int(round((x - self.x[0]) / self.dx))
+    iy = int(round((y - self.y[0]) / self.dy))
+    if 0 <= ix < len(self.x) and 0 <= iy < len(self.y): return (iy, ix)
+    return None
+
+#------------------------------------------------------------------------------
+
+class DetPix:
+  """Contents of one Lux data file. Use det_pix.read() to make one."""
+
+  def __init__(self, file_name, params, columns, data):
+    self.file_name = file_name
+    self.params    = params
+    self.columns   = columns
+    self.data      = data
+
+    if 'ix' in columns and 'iy' in columns:
+      self.kind = 'pix'         # The det_pix file itself: 2D pixel data.
+      self.coords = ['ix', 'iy', 'x_pix', 'y_pix']
+    elif 'ix' in columns:
+      self.kind = 'x'           # det_pix.x: projection onto the x axis.
+      self.coords = ['ix', 'x_pix']
+    elif 'iy' in columns:
+      self.kind = 'y'           # det_pix.y: projection onto the y axis.
+      self.coords = ['iy', 'y_pix']
+    else:
+      self.kind = 'histogram'   # det_pix.histogram. Column 1 is the bin value.
+      self.coords = columns[:2]
+
+  #----------------------------------------------------------------------------
+
+  @property
+  def is_2d(self):
+    return self.kind == 'pix'
+
+  def resolve(self, name):
+    """Full column name from an alias, exact name or unambiguous abbreviation."""
+    key = name.strip().lower()
+    key = ALIASES.get(key, key)
+    if key in self.columns: return key
+
+    hit = [c for c in self.columns if c.startswith(key)]
+    if len(hit) == 1: return hit[0]
+    if len(hit) > 1:
+      raise DetPixError('Ambiguous column name "%s". Matches: %s' % (name, ', '.join(hit)))
+    raise DetPixError('No such column: "%s". Known columns: %s' % (name, ', '.join(self.columns)))
+
+  def col(self, name):
+    """1D array of column <name>."""
+    return self.data[:, self.columns.index(self.resolve(name))]
+
+  def plottable(self):
+    """Columns worth plotting -- that is, everything but the coordinates."""
+    return [c for c in self.columns if c not in self.coords]
+
+  #----------------------------------------------------------------------------
+
+  def pixel_size(self, axis):
+    """Pixel size along 'x' or 'y', from the header if it is there."""
+    p = self.params.get('d%s_pixel' % axis)
+    if p: return float(p)
+
+    # Fall back on the data: <coord> = index * pixel_size + offset.
+    ix, r = self.col('i' + axis), self.col('%s_pix' % axis)
+    if len(ix) > 1 and ix.max() > ix.min():
+      return float(np.polyfit(ix, r, 1)[0])
+    raise DetPixError('Cannot determine the pixel size along %s.' % axis)
+
+  def _axis_coords(self, axis, i_min, i_max):
+    """Pixel center coordinates for pixel indices i_min ... i_max."""
+    d = self.pixel_size(axis)
+    ix, r = self.col('i' + axis), self.col('%s_pix' % axis)
+    offset = float(np.mean(r - ix * d)) if len(ix) else 0.0   # Detector r0.
+    return d, np.arange(i_min, i_max+1) * d + offset
+
+  def active_range(self, axis):
+    """Pixel index range holding the data: (min, max)."""
+    lo, hi = self.params.get('n%s_active_min' % axis), self.params.get('n%s_active_max' % axis)
+    idx = self.col('i' + axis)
+    if len(idx) == 0:
+      if lo is None: raise DetPixError('%s: no data.' % self.file_name)
+      return int(lo), int(hi)
+    lo = int(idx.min()) if lo is None else min(int(lo), int(idx.min()))
+    hi = int(idx.max()) if hi is None else max(int(hi), int(idx.max()))
+    return lo, hi
+
+  #----------------------------------------------------------------------------
+
+  def image(self, name, margin = 0, scale = 1.0, fill = None):
+    """Column <name> put onto the 2D pixel grid. Returns a Grid.
+
+    margin -- Number of blank pixels to pad the active area with.
+    scale  -- Multiplies the coordinates. 1e3 gives millimeters.
+    fill   -- Value for pixels not in the file. Defaults to 0 for intensity-like
+              columns and NaN for the rest (an average over no photons is not a
+              number, and NaN keeps it out of the color scale).
+    """
+    if not self.is_2d:
+      raise DetPixError('%s is not a 2D pixel file.' % self.file_name)
+
+    name = self.resolve(name)
+    if fill is None: fill = 0.0 if name in _EXTENSIVE else np.nan
+
+    ix_min, ix_max = self.active_range('x')
+    iy_min, iy_max = self.active_range('y')
+    ix_min -= margin;  ix_max += margin
+    iy_min -= margin;  iy_max += margin
+
+    z = np.full((iy_max+1-iy_min, ix_max+1-ix_min), float(fill))
+    ix = np.rint(self.col('ix')).astype(int) - ix_min
+    iy = np.rint(self.col('iy')).astype(int) - iy_min
+    z[iy, ix] = self.col(name)
+
+    dx, x = self._axis_coords('x', ix_min, ix_max)
+    dy, y = self._axis_coords('y', iy_min, iy_max)
+    return Grid(z, scale*x, scale*y, scale*dx, scale*dy, ix_min, iy_min, name)
+
+  def curve(self, name, scale = 1.0):
+    """(abscissa, value) arrays for a 1D (.x, .y or .histogram) file.
+
+    <scale> applies to detector positions only. The abscissa of a histogram is
+    whatever lux_param%histogram_variable was, so it is left alone.
+    """
+    if self.is_2d: raise DetPixError('%s is 2D pixel data. Use image().' % self.file_name)
+    if self.kind == 'histogram': return self.data[:, 1], self.col(name)
+    return scale * self.col('%s_pix' % self.kind), self.col(name)
+
+  #----------------------------------------------------------------------------
+
+  def title(self):
+    """One line description of where the data came from."""
+    bits = [os.path.basename(self.file_name)]
+    if 'lattice_file' in self.params: bits.append(str(self.params['lattice_file']))
+    n = self.params.get('n_track_tot')
+    if n: bits.append('%g photons tracked' % n)
+    return '   |   '.join(bits)
+
+#------------------------------------------------------------------------------
+
+def _parse_value(text):
+  """Value of a header parameter: string, bool, int or float."""
+  text = text.strip()
+  if text[:1] in ('"', "'"):
+    end = text.find(text[0], 1)
+    return text[1:end] if end > 0 else text[1:]
+
+  text = text.split('#')[0].strip()     # Lux puts a comment after some values.
+  if text.upper() in ('T', '.TRUE.'):  return True
+  if text.upper() in ('F', '.FALSE.'): return False
+  for cast in (int, float):
+    try: return cast(text)
+    except ValueError: pass
+  return text
+
+#------------------------------------------------------------------------------
+
+def _parse_columns(line, n_col):
+  """Column names from the header line. Names after a "|" get an init_ prefix."""
+  groups = line.lstrip('#').split('|')
+  names = [c.lower() for c in groups[0].split()]
+  for g in groups[1:]:
+    names += ['init_' + c.lower() for c in g.split()]
+
+  if len(names) != n_col:      # Do not guess if the header does not add up.
+    names = ['col%d' % i for i in range(n_col)]
+  return names
+
+#------------------------------------------------------------------------------
+
+def read(file_name):
+  """Read a Lux det_pix file (or its .x, .y, .histogram companion)."""
+
+  params, comments, rows = {}, [], []
+  in_header = True
+
+  with open(file_name) as f:
+    for line in f:
+      line = line.rstrip('\n')
+      if not line.strip(): continue
+
+      if line.lstrip().startswith('#') or in_header:
+        if _SEPARATOR.match(line):
+          in_header = False
+          comments = []
+          continue
+        match = _PARAM.match(line) if in_header else None
+        if match:
+          params[match.group(1).lower()] = _parse_value(match.group(2))
+        else:
+          comments.append(line)
+        continue
+
+      rows.append(line.split())
+
+  if not rows: raise DetPixError('No data rows found in: ' + file_name)
+
+  n_col = max(len(r) for r in rows)
+  if any(len(r) != n_col for r in rows):
+    raise DetPixError('Rows with differing numbers of columns in: ' + file_name)
+
+  try:
+    data = np.array(rows, dtype = float)
+  except ValueError as err:      # Fortran writes "****" for numbers that overflow.
+    raise DetPixError('Cannot read the numbers in %s: %s' % (file_name, err))
+
+  columns = _parse_columns(comments[-1] if comments else '', n_col)
+  return DetPix(file_name, params, columns, data)
+
+#------------------------------------------------------------------------------
+
+if __name__ == '__main__':
+  import sys
+  if len(sys.argv) != 2:
+    sys.exit('Usage: det_pix.py <file>    # Print a summary of the file.')
+
+  dp = read(sys.argv[1])
+  print('File:    %s  (%s)' % (dp.file_name, dp.kind))
+  print('Rows:    %d' % len(dp.data))
+  print('\nHeader parameters:')
+  for k, v in dp.params.items(): print('  %-35s %s' % (k, v))
+  print('\nColumns:')
+  for c in dp.columns:
+    v = dp.col(c)
+    print('  %-20s min = %12.5g   max = %12.5g   sum = %12.5g' % (c, v.min(), v.max(), v.sum()))

--- a/lux/scripts/plot_det_pix.py
+++ b/lux/scripts/plot_det_pix.py
@@ -1,151 +1,519 @@
 #!/usr/bin/env python3
 
-# To execute this file from within the Python interpreter:
-#   execfile('this_file_name')
+"""
+Interactive viewer for the Lux det_pix_out_file and its ".x", ".y" and
+".histogram" companions.
 
+  plot_det_pix.py spherical.det_pix
+
+Once the window is up, everything is changeable without rerunning the script:
+pick any column in the file from the list on the left, switch between linear
+and log color scales, cycle colormaps, and click on the image to cut horizontal
+and vertical lineouts through that point. Zoom and pan with the usual matplotlib
+toolbar.
+
+Run with -h for the command line arguments, and press "?" in the window for the
+key bindings.
+
+To work with the data yourself, in a script or in an interactive session, use
+the reader module directly:
+
+  from det_pix import read
+  dp = read('spherical.det_pix')
+  x, y = dp.curve('intensity')           # For a .x or .y file.
+  grid = dp.image('e_ave', scale = 1e3)  # For the det_pix file itself.
+"""
+
+import os
 import sys
-import re
+import glob
+import argparse
+import warnings
+
 import numpy as np
-import matplotlib.pyplot as plt
-import matplotlib.ticker as ticker
+import matplotlib
+from matplotlib import ticker
+from matplotlib.colors import Normalize, LogNorm
+from matplotlib.widgets import RadioButtons, CheckButtons, Button
 
-T = True    # For converting from det_pix file header T/F notation
-F = False
+import det_pix
 
-# Check version
+plt = None      # matplotlib.pyplot, imported by main() after the backend is set.
 
-if sys.version_info[0] < 3: sys.exit("MUST USE PYTHON3!")
+#------------------------------------------------------------------------------
+# Colormaps. Sequential (single ramp, dark to light) for magnitudes, diverging
+# (two hues about a neutral middle) for quantities that change sign, and cyclic
+# for phases. First in each list is the default.
 
-# Help
+CMAPS = {
+  'sequential': ['inferno', 'viridis', 'magma', 'cividis', 'Greys_r', 'gnuplot2'],
+  'diverging':  ['RdBu_r', 'coolwarm', 'PuOr_r'],
+  'cyclic':     ['twilight', 'twilight_shifted', 'hsv'],
+}
 
-def print_help():
-  print ('''
-Usage:
-  det_pix_plot.py {-aspect <aspect_ratio>} {-scale <scale>} {-plot <who_to_plot>} {<data_file_name>}
+EMPTY_COLOR = '#9a9a9a'    # Pixels with no data. Neither end of any colormap.
+LINE_COLOR  = '#1a6fdf'
+CUT_COLOR   = '#e8590c'
 
-  <who_to_plot> = x         # Intensity of x-polarized photons
-                = y         # Intensity of y-polarized photons
-                = i         # Total intensity (sum of x & y polarizations)
-                = e         # Energy
-  Defaults:
-    <aspect_ratio>   = 1
-    <scale>          = 1e3
-    <data_file_name> = det_pix
-    <who_to_plot>    = i
-''')
-  exit() 
+UNITS = {1: 'm', 1e2: 'cm', 1e3: 'mm', 1e6: r'$\mu$m', 1e9: 'nm'}
 
-# Defaults
+# Figure layout, in fractions of the figure. The image gets IMG_RECT; the
+# lineout panels and the colorbar are hung off whatever box it ends up with.
 
-dat_file_name = 'det.pix'
+IMG_RECT = [0.28, 0.10, 0.42, 0.60]
+PAD, TOP_H, RIGHT_W, CBAR_W, CBAR_PAD = 0.012, 0.15, 0.10, 0.017, 0.045
 
-scale = 1e3
-aspect = 1
+#------------------------------------------------------------------------------
 
-x_margin = 10
-y_margin = 10
-who_to_plot = 'i'
+def color_kind(name, z):
+  """Which family of colormap suits column <name> with values <z>."""
+  if name.startswith('phase'): return 'cyclic'
+  z = z[np.isfinite(z)]
+  if len(z) and z.min() < 0 < z.max(): return 'diverging'
+  return 'sequential'
 
-# Command line arguments
+#------------------------------------------------------------------------------
 
-i = 1
-while i < len(sys.argv):
-  n = len(sys.argv[i])
-  if sys.argv[i] == '-':
-    print_help()
-    
-  if sys.argv[i] == '-scale'[:n]:
-    scale = float(sys.argv[i+1])
-    i += 1
+def make_norm(z, kind, log):
+  """Color scale limits for values <z>."""
+  z = z[np.isfinite(z)]
+  if len(z) == 0: return Normalize(0, 1)
 
-  if sys.argv[i] == '-aspect'[:n]:
-    aspect = float(sys.argv[i+1])
-    i += 1
+  if kind == 'cyclic':
+    return Normalize(-np.pi, np.pi)
 
-  elif sys.argv[i] == '-plot'[:n]:
-    who_to_plot = sys.argv[i+1]
-    i += 1
+  if kind == 'diverging':
+    # Symmetric about zero so that the neutral middle color means zero. The
+    # percentile keeps a single wild pixel from flattening everything else.
+    a = np.percentile(np.abs(z), 99.5)
+    if a == 0: a = max(np.abs(z).max(), 1e-30)
+    return Normalize(-a, a)
 
-  elif sys.argv[i][0] == '-':
-    print_help()
-    
-  else:
-    dat_file_name = sys.argv[i]
+  if log:
+    pos = z[z > 0]
+    if len(pos): return LogNorm(max(pos.min(), z.max()/1e6), z.max())
 
-  i += 1
+  lo, hi = z.min(), z.max()
+  return Normalize(lo, hi if hi > lo else lo + 1)
 
-# Select appropriate column in file to use.
-# First column has index 0.
+#------------------------------------------------------------------------------
 
-if who_to_plot == 'x':
-  p_col = 4
-elif who_to_plot == 'y':
-  p_col = 6
-elif who_to_plot == 'i':
-  p_col = 8
-elif who_to_plot == 'e':
-  p_col = 10
-else:
-  print_help()
+def step_curve(centers, values, d):
+  """Polyline drawing <values> as a bar-like step curve over the pixel bins."""
+  edges = np.concatenate([centers - d/2, [centers[-1] + d/2]])
+  return np.repeat(edges, 2)[1:-1], np.repeat(values, 2)
 
-# Read data file parameters in header lines and data file data
+#------------------------------------------------------------------------------
 
-dat_file = open (dat_file_name)
+class Viewer:
+  """The det_pix window: image, lineouts and the controls for both."""
 
-for n_header in range(1, 1000):
-  line = dat_file.readline()
-  if line[0:3] == '#--': break
-  if (line[0] == '#'): line = line[1:] # Remove beginning "#". Old style did not have beginning "#".
-  line = line.strip() 
-  print (line) 
-  exec (line)
+  HELP = '''
+Keys:
+  n / p    Next / previous quantity        l    Linear <-> log color scale
+  m        Lineout mode: sum <-> cut       c    Next colormap
+  a        Equal aspect on / off           ?    This message
+  Click on the image to move the cut. Toolbar keys (s = save, o = zoom,
+  h = unzoom, q = quit) work as usual.
+'''
 
-dat_file.close()
+  def __init__(self, dp, args):
+    self.dp     = dp
+    self.args   = args
+    self.name   = dp.resolve(args.plot) if args.plot else self.first_quantity()
+    self.names  = dp.plottable()
+    self.log    = args.log
+    self.equal  = True
+    self.cut    = None            # (ix, iy) array indices, or None for sums.
+    self.cmap_i = 0
+    self.unit   = UNITS.get(args.scale, '%g m' % (1/args.scale))
+    self.unit_text = self.unit.replace(r'$\mu$', 'u')     # No math for the toolbar.
+    self.build()
 
-pix_dat = np.loadtxt(dat_file_name, usecols=(0,1,p_col), skiprows = n_header)
+  def first_quantity(self):
+    for name in ('intensity', 'intens_x'):
+      if name in self.dp.columns: return name
+    return self.dp.plottable()[0]
 
-## print(str(pix_dat))
+  #----------------------------------------------------------------------------
 
-# Create density matrix
+  def build(self):
+    self.fig = plt.figure(figsize = (11.5, 7.5))
+    self.fig.canvas.manager.set_window_title(os.path.basename(self.dp.file_name))
 
-nx_min = nx_active_min - x_margin  # For border
-nx_max = nx_active_max + x_margin
-ny_min = ny_active_min - y_margin  # For border
-ny_max = ny_active_max + y_margin
+    self.ax_img   = self.fig.add_axes(IMG_RECT)
+    self.ax_top   = self.fig.add_axes([0, 0, 1, 1], sharex = self.ax_img)
+    self.ax_right = self.fig.add_axes([0, 0, 1, 1], sharey = self.ax_img)
+    self.ax_cbar  = self.fig.add_axes([0, 0, 1, 1])
+    self.sync_panels()
 
-print ('nx min/max: ' + str(nx_min) + ', ' + str(nx_max))
-print ('ny min/max: ' + str(ny_min) + ', ' + str(ny_max))
+    for ax in (self.ax_top, self.ax_right):
+      ax.grid(True, lw = 0.4, color = '#cccccc', alpha = 0.7)
+      ax.tick_params(labelsize = 7)
+      for side in ('top', 'right'): ax.spines[side].set_visible(False)
+    plt.setp(self.ax_top.get_xticklabels(), visible = False)
+    plt.setp(self.ax_right.get_yticklabels(), visible = False)
+    self.ax_top.yaxis.get_offset_text().set_fontsize(6)
+    self.ax_right.xaxis.get_offset_text().set_fontsize(6)
 
-pix_mat = np.zeros((nx_max+1-nx_min, ny_max+1-ny_min))
+    self.ax_img.set_xlabel('x (%s)' % self.unit)
+    self.ax_img.set_ylabel('y (%s)' % self.unit)
+    self.ax_img.tick_params(labelsize = 8)
 
-for pix in pix_dat:
-  pix_mat[int(round(pix[0]))-nx_min, int(round(pix[1]))-ny_min] = pix[2]
+    grid = self.grid()
+    self.im = self.ax_img.imshow(grid.z, origin = 'lower', extent = grid.extent,
+                                 interpolation = 'nearest')
+    self.cbar = self.fig.colorbar(self.im, cax = self.ax_cbar)
+    self.ax_cbar.tick_params(labelsize = 7)
 
-# And plot
+    self.line_top,   = self.ax_top.plot([], [], lw = 1.1, color = LINE_COLOR)
+    self.line_right, = self.ax_right.plot([], [], lw = 1.1, color = LINE_COLOR)
+    self.vline = self.ax_img.axvline(np.nan, lw = 0.8, color = CUT_COLOR, alpha = 0.9)
+    self.hline = self.ax_img.axhline(np.nan, lw = 0.8, color = CUT_COLOR, alpha = 0.9)
 
-x_min = scale * nx_min * dx_pixel
-x_max = scale * nx_max * dx_pixel
-y_min = scale * ny_min * dy_pixel
-y_max = scale * ny_max * dy_pixel
+    self.cut_label = self.ax_top.text(0.5, 1.22, '', va = 'bottom', ha = 'center', fontsize = 8,
+                                      color = '#444444', transform = self.ax_top.transAxes)
+    self.ax_img.format_coord = self.format_coord   # Cursor readout in the toolbar.
+    self.fig.suptitle('%s\n%s' % (self.dp.title(), self.run_summary()),
+                      fontsize = 8.5, color = '#444444', linespacing = 1.6)
+    self.build_controls()
+    self.connect()
+    self.refresh(reset_limits = True)
 
-if 'ix_plot' not in locals(): ix_plot = 0
-ix_plot = ix_plot + 1
+  #----------------------------------------------------------------------------
 
-fig = plt.figure(ix_plot)
-ax = fig.add_subplot(111)
+  def sync_panels(self, event = None):
+    """Keep the lineouts and the colorbar glued to the image.
 
-if x_max-x_min > y_max - y_min:
-  it = max(1, int((y_max-y_min) * 8 / (x_max-x_min)))
-  ax.yaxis.set_major_locator(ticker.MaxNLocator(it))
-else:
-  it = max(1, int((x_max-x_min) * 8 / (y_max-y_min)))
-  ax.xaxis.set_major_locator(ticker.MaxNLocator(it))
+    Needed because matplotlib shrinks the image box, not the axes rectangle,
+    when the aspect ratio is locked -- and it shrinks it by a different amount
+    every time the plot is zoomed.
+    """
+    p = self.ax_img.get_position()
+    wanted = ((self.ax_top,   [p.x0, p.y1 + PAD, p.width, TOP_H]),
+              (self.ax_right, [p.x1 + PAD, p.y0, RIGHT_W, p.height]),
+              (self.ax_cbar,  [p.x1 + 2*PAD + RIGHT_W + CBAR_PAD, p.y0, CBAR_W, p.height]))
 
-dens = ax.imshow(np.transpose(pix_mat), origin = 'lower', extent = (x_min, x_max, y_min, y_max), aspect = aspect)
-dens.set_cmap('gnuplot2')
+    moved = False
+    for ax, box in wanted:
+      now = ax.get_position()
+      if max(abs(a - b) for a, b in zip([now.x0, now.y0, now.width, now.height], box)) > 1e-4:
+        ax.set_position(box)
+        moved = True
+    if moved and event is not None: self.fig.canvas.draw_idle()
 
-##plt.set_cmap('gnuplot2_r')
+  def build_controls(self):
+    n = len(self.names)
+    ax = self.fig.add_axes([0.012, max(0.28, 0.90 - 0.031*n), 0.20, min(0.62, 0.031*n)])
+    ax.set_title('Quantity', fontsize = 8.5, loc = 'left')
+    ax.set_facecolor('#f7f7f7')
+    self.radio = RadioButtons(ax, self.names, active = self.names.index(self.name))
+    for label in self.radio.labels: label.set_fontsize(7)
+    self.radio.on_clicked(self.on_quantity)
 
-fig.colorbar(dens)
+    ax = self.fig.add_axes([0.012, 0.155, 0.20, 0.10])
+    ax.set_facecolor('#f7f7f7')
+    self.check = CheckButtons(ax, ['log scale', 'equal aspect', 'cut at cursor'],
+                              [self.log, True, False])
+    for label in self.check.labels: label.set_fontsize(7.5)
+    self.check.on_clicked(self.on_check)
 
-plt.show()
+    self.button = Button(self.fig.add_axes([0.012, 0.10, 0.20, 0.04]), 'colormap',
+                         color = '#eeeeee')
+    self.button.label.set_fontsize(8)
+    self.button.on_clicked(lambda event: self.cycle_cmap())
+
+    self.fig.text(0.012, 0.055, 'n/p quantity   l log   m mode\nc colormap   a aspect   ? help',
+                  fontsize = 7, family = 'monospace', color = '#777777')
+
+  def connect(self):
+    # Free up the keys used below from the default matplotlib bindings.
+    for param, key in (('keymap.yscale', 'l'), ('keymap.pan', 'p'), ('keymap.back', 'c')):
+      plt.rcParams[param] = [k for k in plt.rcParams[param] if k != key]
+    self.fig.canvas.mpl_connect('draw_event', self.sync_panels)
+    self.fig.canvas.mpl_connect('key_press_event', self.on_key)
+    self.fig.canvas.mpl_connect('button_press_event', self.on_click)
+
+  #----------------------------------------------------------------------------
+
+  def grid(self, name = None):
+    return self.dp.image(name or self.name, margin = self.args.margin, scale = self.args.scale)
+
+  def refresh(self, reset_limits = False):
+    """Redraw everything for the current quantity and settings."""
+    g = self.grid()
+    self.z, self.gx, self.gy = g.z, g.x, g.y
+    self.dx, self.dy = g.dx, g.dy
+    self.ix0, self.iy0 = g.ix0, g.iy0
+
+    kind = color_kind(self.name, g.z)
+    name = self.args.cmap or CMAPS[kind][self.cmap_i % len(CMAPS[kind])]
+    cmap = plt.get_cmap(name).with_extremes(bad = EMPTY_COLOR)   # Needs matplotlib 3.4.
+
+    log = self.log and kind == 'sequential'
+    self.im.set_data(g.z)
+    self.im.set_cmap(cmap)
+    self.im.set_norm(make_norm(g.z, kind, log))
+    self.im.set_extent(g.extent)
+    self.cbar.update_normal(self.im)
+    self.ax_cbar.set_ylabel('%s%s' % (self.name, '  (log)' if log else ''), fontsize = 8)
+    self.ax_img.set_aspect(self.args.aspect if self.equal else 'auto')
+
+    if reset_limits:
+      self.ax_img.set_xlim(g.extent[0], g.extent[1])
+      self.ax_img.set_ylim(g.extent[2], g.extent[3])
+
+    self.refresh_cuts()
+    self.fig.canvas.draw_idle()
+
+  def refresh_cuts(self):
+    """Redraw the two lineout panels."""
+    z = self.z
+    if self.cut is None:
+      how = np.nansum if self.name in det_pix._EXTENSIVE else np.nanmean
+      with warnings.catch_warnings():
+        warnings.simplefilter('ignore')          # Blank rows: the mean of nothing.
+        vx, vy = how(z, axis = 0), how(z, axis = 1)
+      what = 'sum' if how is np.nansum else 'mean'
+      title = '%s of %s over all pixels' % (what, self.name)
+      self.vline.set_xdata([np.nan]);  self.hline.set_ydata([np.nan])
+    else:
+      ix, iy = self.cut
+      vx, vy = z[iy,:], z[:,ix]
+      title = '%s cut at x = %.4g, y = %.4g %s' % (self.name, self.gx[ix], self.gy[iy], self.unit)
+      self.vline.set_xdata([self.gx[ix]]);  self.hline.set_ydata([self.gy[iy]])
+
+    vx = np.where(np.isfinite(vx), vx, np.nan)
+    vy = np.where(np.isfinite(vy), vy, np.nan)
+    self.line_top.set_data(*step_curve(self.gx, vx, self.dx))
+    self.line_right.set_data(*reversed(step_curve(self.gy, vy, self.dy)))
+    self.cut_label.set_text(title)
+
+    good = vx[np.isfinite(vx)]
+    log = self.log and len(good) > 0 and good.min() >= 0
+    self.ax_top.set_yscale('log' if log else 'linear')
+    self.ax_right.set_xscale('log' if log else 'linear')
+
+    # The lineout panels are narrow, so hold down the number of tick labels.
+    for axis in (self.ax_top.yaxis, self.ax_right.xaxis):
+      if log:
+        axis.set_major_locator(ticker.LogLocator(numticks = 4))
+        axis.set_minor_locator(ticker.NullLocator())
+      else:
+        axis.set_major_locator(ticker.MaxNLocator(3))
+        fmt = ticker.ScalarFormatter()
+        fmt.set_powerlimits((-3, 4))       # Long numbers become a common factor.
+        axis.set_major_formatter(fmt)
+
+    for ax, scaley in ((self.ax_top, True), (self.ax_right, False)):
+      ax.relim()
+      ax.autoscale_view(scalex = not scaley, scaley = scaley)
+    self.fig.canvas.draw_idle()
+
+  def run_summary(self):
+    """Second title line: the header numbers worth having in front of you."""
+    p, bits = self.dp.params, []
+    for label, key, is_coord in (('at detector', 'n_at_detec', False),
+                                 ('intensity', 'intensity_norm', False),
+                                 ('x center', 'x_center_det', True),
+                                 ('y center', 'y_center_det', True),
+                                 ('x rms', 'x_rms_det', True), ('y rms', 'y_rms_det', True)):
+      if key not in p: continue
+      if is_coord: bits.append('%s = %.4g %s' % (label, p[key] * self.args.scale, self.unit))
+      else: bits.append('%s = %.5g' % (label, p[key]))
+    return '   |   '.join(bits)
+
+  #----------------------------------------------------------------------------
+  # Callbacks.
+
+  def on_quantity(self, name):
+    self.name = name
+    self.refresh()
+
+  def on_check(self, label):
+    self.log, self.equal, cut_mode = self.check.get_status()
+    if not cut_mode: self.cut = None
+    elif self.cut is None: self.cut = (len(self.gx)//2, len(self.gy)//2)
+    self.refresh()
+
+  def pixel_at(self, x, y):
+    """Array indices (ix, iy) of the pixel at plot position (x, y), or None."""
+    if x is None or y is None: return None
+    ix = int(round((x - self.gx[0]) / self.dx))
+    iy = int(round((y - self.gy[0]) / self.dy))
+    if 0 <= ix < len(self.gx) and 0 <= iy < len(self.gy): return (ix, iy)
+    return None
+
+  def on_click(self, event):
+    if event.inaxes is not self.ax_img or event.button != 1: return
+    if self.fig.canvas.toolbar and self.fig.canvas.toolbar.mode: return   # Zooming.
+    ij = self.pixel_at(event.xdata, event.ydata)
+    if ij is None: return
+    self.cut = ij
+    if not self.check.get_status()[2]: self.check.set_active(2)           # Calls on_check.
+    else: self.refresh_cuts()
+
+  def format_coord(self, x, y):
+    """What the toolbar shows as the cursor moves over the image."""
+    ij = self.pixel_at(x, y)
+    if ij is None: return 'x = %.4g   y = %.4g %s' % (x, y, self.unit_text)
+    ix, iy = ij
+    return 'x = %.4g   y = %.4g %s      pixel (%d, %d)      %s = %.6g' % (
+           self.gx[ix], self.gy[iy], self.unit_text, ix + self.ix0, iy + self.iy0,
+           self.name, self.z[iy,ix])
+
+  def on_key(self, event):
+    if event.key in ('n', 'p'):
+      i = (self.names.index(self.name) + (1 if event.key == 'n' else -1)) % len(self.names)
+      self.radio.set_active(i)                     # Calls on_quantity.
+    elif event.key == 'l':   self.check.set_active(0)
+    elif event.key == 'a':   self.check.set_active(1)
+    elif event.key == 'm':   self.check.set_active(2)
+    elif event.key == 'c':   self.cycle_cmap()
+    elif event.key == '?':   print(self.HELP)
+
+  def cycle_cmap(self):
+    self.args.cmap = None
+    self.cmap_i += 1
+    self.refresh()
+
+#------------------------------------------------------------------------------
+
+def plot_1d(dp, args):
+  """Viewer for the .x, .y and .histogram files: one curve, pick the column."""
+
+  names = dp.plottable()
+  name = dp.resolve(args.plot) if args.plot else ('intensity' if 'intensity' in names else names[0])
+  unit = UNITS.get(args.scale, '%g m' % (1/args.scale))
+
+  fig = plt.figure(figsize = (10, 6))
+  fig.canvas.manager.set_window_title(os.path.basename(dp.file_name))
+  fig.suptitle(dp.title(), fontsize = 9, color = '#444444')
+  ax = fig.add_axes([0.31, 0.10, 0.64, 0.80])
+  ax.grid(True, lw = 0.4, color = '#cccccc', alpha = 0.7)
+  for side in ('top', 'right'): ax.spines[side].set_visible(False)
+  ax.set_xlabel(('%s (%s)' % (dp.kind, unit)) if dp.kind in ('x', 'y') else dp.columns[1])
+
+  r, v = dp.curve(name, scale = args.scale)
+  curve, = ax.plot(r, v, lw = 1.2, color = LINE_COLOR)
+  ax.set_ylabel(name)
+  if args.log: ax.set_yscale('log')
+
+  ax_radio = fig.add_axes([0.02, max(0.16, 0.90 - 0.031*len(names)), 0.22, min(0.74, 0.031*len(names))])
+  ax_radio.set_title('Quantity', fontsize = 8.5, loc = 'left')
+  ax_radio.set_facecolor('#f7f7f7')
+  radio = RadioButtons(ax_radio, names, active = names.index(name))
+  for label in radio.labels: label.set_fontsize(7)
+
+  ax_check = fig.add_axes([0.02, 0.09, 0.22, 0.045])
+  ax_check.set_facecolor('#f7f7f7')
+  check = CheckButtons(ax_check, ['log scale'], [args.log])
+  for label in check.labels: label.set_fontsize(7.5)
+
+  def on_pick(new_name):
+    curve.set_ydata(dp.curve(new_name, scale = args.scale)[1])
+    ax.set_ylabel(new_name)
+    ax.relim();  ax.autoscale_view()
+    fig.canvas.draw_idle()
+
+  def on_log(label):
+    ax.set_yscale('log' if check.get_status()[0] else 'linear')
+    fig.canvas.draw_idle()
+
+  def on_key(event):
+    if event.key in ('n', 'p'):
+      i = (names.index(ax.get_ylabel()) + (1 if event.key == 'n' else -1)) % len(names)
+      radio.set_active(i)
+    elif event.key == 'l': check.set_active(0)
+
+  plt.rcParams['keymap.yscale'] = [k for k in plt.rcParams['keymap.yscale'] if k != 'l']
+  radio.on_clicked(on_pick)
+  check.on_clicked(on_log)
+  fig.canvas.mpl_connect('key_press_event', on_key)
+  fig._widgets = (radio, check)        # Keep the widgets alive.
+  return fig
+
+#------------------------------------------------------------------------------
+
+def find_data_file():
+  """Default input file: det.pix, or the only det_pix file in this directory."""
+  if os.path.exists('det.pix'): return 'det.pix'
+  hits = [f for f in glob.glob('*det_pix*') + glob.glob('*.pix')
+          if not f.endswith(('.x', '.y', '.histogram'))]
+  if len(hits) == 1:
+    print('Using data file: ' + hits[0])
+    return hits[0]
+  sys.exit('No data file given and cannot guess one. Candidates here: %s' %
+           (', '.join(hits) if hits else 'none'))
+
+#------------------------------------------------------------------------------
+
+def parse_args():
+  p = argparse.ArgumentParser(description = 'Interactive plot of a Lux det_pix file.',
+                              formatter_class = argparse.ArgumentDefaultsHelpFormatter)
+  p.add_argument('data_file', nargs = '?', help = 'det_pix file. Default: det.pix')
+  p.add_argument('-plot', '--plot', metavar = 'COL', default = None,
+                 help = 'Column to plot. Name, abbreviation, or one of the old '
+                        'x (Intens_x), y (Intens_y), i (Intensity), e (E_ave). '
+                        'Default: intensity')
+  p.add_argument('-scale', '--scale', type = float, default = 1e3,
+                 help = 'Coordinate scale. 1e3 -> mm')
+  p.add_argument('-aspect', '--aspect', type = float, default = 1.0,
+                 help = 'Aspect ratio of the image')
+  p.add_argument('-margin', '--margin', type = int, default = 4,
+                 help = 'Blank pixels around the active area')
+  p.add_argument('-cmap', '--cmap', default = None,
+                 help = 'Colormap. Default: chosen to suit the quantity')
+  p.add_argument('-log', '--log', action = 'store_true', help = 'Start with a log color scale')
+  p.add_argument('-save', '--save', metavar = 'FILE', default = None, help = 'Write the plot to FILE')
+  p.add_argument('-noshow', '--noshow', action = 'store_true', help = 'Do not open a window')
+  p.add_argument('-dpi', '--dpi', type = int, default = 150, help = 'Resolution of the saved plot')
+  p.add_argument('-list', '--list', action = 'store_true',
+                 help = 'List the file contents and exit')
+  return p.parse_args()
+
+#------------------------------------------------------------------------------
+
+def main():
+  global plt
+
+  args = parse_args()
+  file_name = args.data_file or find_data_file()
+
+  try:
+    dp = det_pix.read(file_name)
+  except (OSError, det_pix.DetPixError) as err:
+    sys.exit('%s' % err)
+
+  if args.list:
+    print('File:    %s  (%s data)' % (dp.file_name, dp.kind))
+    print('Rows:    %d' % len(dp.data))
+    print('\nHeader parameters:')
+    for k, v in dp.params.items(): print('  %-35s %s' % (k, v))
+    print('\nPlottable columns:')
+    for c in dp.plottable():
+      v = dp.col(c)
+      print('  %-20s min = %11.4g  max = %11.4g' % (c, v.min(), v.max()))
+    return
+
+  if args.noshow: matplotlib.use('Agg')
+  import matplotlib.pyplot as pyplot
+  plt = pyplot
+
+  try:
+    view = Viewer(dp, args) if dp.is_2d else plot_1d(dp, args)
+  except det_pix.DetPixError as err:
+    sys.exit('%s' % err)
+
+  fig = view.fig if isinstance(view, Viewer) else view
+  if args.save:
+    fig.savefig(args.save, dpi = args.dpi)
+    print('Wrote: ' + args.save)
+  if not args.noshow:
+    print(Viewer.HELP)
+    plt.show()
+
+#------------------------------------------------------------------------------
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
## Summary

Reworks the two Lux `det_pix` scripts and adds a reader module they share.

**`plot_det_pix.py`** was a one-shot script — the quantity, color scale and colormap were fixed at the command line, and the file header was parsed by calling `exec()` on it. It is now an interactive viewer:

- Any column in the file can be picked from a list in the window; no rerunning.
- Linear/log color scale, colormap cycling, equal-aspect toggle.
- Click on the image to cut horizontal and vertical lineouts through that point. With no cut selected the panels show the sum (for intensities) or the mean (for averages) over all pixels.
- The toolbar readout gives the pixel index and the value under the cursor.
- Colormaps suit the quantity: a single ramp for magnitudes, a diverging pair about a neutral zero for quantities that change sign, a cyclic map for phases. Pixels with no data are drawn in a gray that is at neither end of any map, so "empty" never reads as "zero" or "maximum".
- The `.x`, `.y` and `.histogram` companion files get their own simpler viewer.
- Still scriptable: `-save FILE -noshow` writes a plot without opening a window, and `-list` dumps the header and the column ranges.

**`det_pix.py`** (new) is the reader all three scripts use. Column names come from the file rather than from hardwired indices, so nothing has to change when Lux gains a column. Usable on its own:

```python
from det_pix import read
dp = read('spherical.det_pix')
grid = dp.image('e_ave', scale = 1e3)     # 2D, in mm
x, y = dp.curve('intensity')              # For a .x or .y file
```

**`combine_det_pix_files.py`** did not work against current Lux output. It read `photons_tracked`, which no longer exists, so any run died with a `NameError`. Beyond that it added *normalized* intensities, which double counts — combining a file with itself doubled the intensity — computed `ang_y_ave` and `ang_y_rms` from the `ang_x` columns, and had a misspelled variable (`normilization_tot`) that discarded the recomputed normalization.

Rewritten around the right semantics: each file is put back on an unnormalized footing using its own `normalization`, the runs are summed, and the total is renormalized by the combined `n_track_tot`. Averages are combined weighted by unnormalized intensity — how Lux forms them in the first place — and rms values through the second moments. Files that disagree on pixel size, normalization coefficient or detector position are rejected with a specific message; coherent input warns that the runs are being added incoherently and the phases dropped. Output is in Lux's own byte format and defaults to `combined.det_pix` (was `dp.dat`), so it round-trips through the plotter.

`lux.tex` gains documentation for the viewer's controls and key bindings, for using `det_pix.py` in your own scripts, and for the combiner — which had no documentation at all, and whose renormalization behavior is not guessable.

## Testing

Run against Lux output from `rowland_circle_spectrometer`, with `DeprecationWarning`, `PendingDeprecationWarning`, `RuntimeWarning` and `UserWarning` all promoted to errors.

- **Plotting**: ten command-line variants (each quantity type, log, custom colormap, zero margin, non-unit aspect, micron scaling, the three 1D files, auto file discovery, abbreviated flags) render without warnings, and the output was inspected.
- **Interactivity**: driven programmatically under the live backend — all 20 quantities through the radio buttons, all key bindings, both lineout modes, the full colormap cycle, click-to-cut (lands on the exact pixel clicked), and the cursor readout on and off the image. Panel alignment holds at aspect 1.0, 0.5 and 3.0. Grid indexing checked pixel by pixel against the file.
- **Combining**: combining a file with itself reproduces every one of the 24 columns exactly. An independent recomputation of a 400k + 600k photon combine matches all 7218 values to the precision Lux prints, across 401 pixels. The combined `normalization` is identical to that of a real 1e6-photon run and the total intensity agrees to 2.5%, consistent with run-to-run scatter. Data rows and banner are byte-for-byte the widths Lux writes. Every error path exits nonzero with a clear message.

## Note, not addressed here

`lux_module.f90:1027` computes the detector-wide centroid as `sum(pixel%pt%orbit(n)) / intens_tot`. Since `pixel%pt%orbit` was divided by each pixel's intensity just above, this sums per-pixel *means* unweighted and divides by a total intensity — so `x_center_det`, `y_center_det`, `x_rms_det` and `y_rms_det` scale with run size rather than converging. The same lattice gives `x_center_det` = -7.8e-4 at 400k photons, -6.0e-4 at 600k, and -1.3e-4 at 1e6; a properly weighted centroid is ~1e-5 and stable. It looks like the intent was `sum(pixel%pt%orbit(n) * pixel%pt%intensity) / intens_tot`. Left alone because it changes Lux output. It affects only those four header values, not the pixel data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
