### PR TITLE
A slice of a slice must inherit the full lord list (#2158)

### DIFF
--- a/bmad/code/create_element_slice.f90
+++ b/bmad/code/create_element_slice.f90
@@ -109,8 +109,13 @@ else
   sliced_ele%lord => ele_in
 endif
 
+! Note: When re-slicing a slice_slave, sliced_ele%lord is set above to ele_in%lord, so sliced_ele has
+! the same lords as ele_in and must inherit ele_in%n_lord. Leaving n_lord = 1 here would hide all but
+! the first lord from em_field_calc (which loops 1 to n_lord), making field_calc = refer_to_lords$
+! return zero field for a slice of a slice of a multi-lord super_slave.
+
 sliced_ele%n_lord = 1
-if (ele_in%slave_status == super_slave$) sliced_ele%n_lord = ele_in%n_lord
+if (ele_in%slave_status == super_slave$ .or. ele_in%slave_status == slice_slave$) sliced_ele%n_lord = ele_in%n_lord
 
 ! Err check. Remember: the element length may be negative
 


### PR DESCRIPTION
Fixes #2158. The one-line fix is @Nathan-Majernik's, from the branch he posted on the issue; commit authorship is his. I verified the diagnosis and the fix.

## Root cause

`create_element_slice` sets `sliced_ele%lord => ele_in%lord` when `ele_in` is itself a `slice_slave`, so the new slice shares `ele_in`'s lord list — but then resets `n_lord` to 1:

```fortran
sliced_ele%n_lord = 1
if (ele_in%slave_status == super_slave$) sliced_ele%n_lord = ele_in%n_lord   ! slice_slave not covered
```

Every lord past the first becomes invisible. A sliced element has `field_calc = refer_to_lords$`, and `em_field_calc` gets its field from `do i = 1, ele%n_lord` (`bmad/code/em_field_calc.f90:161`), so it saw only lord #1. For an element superimposed on a pipe or drift, lord #1 is the *pipe* — the slice tracked with zero field.

The rest of the code already assumes a `slice_slave` carries its full lord list: `compute_reference_energy.f90:1023` walks `do ii = 1, ele%n_lord` specifically to skip past pipe lords and find the real one, and with `n_lord = 1` it stopped on the pipe and computed `beta0` from the wrong element.

## How the reported case reaches it

The four conditions in the issue are exactly the four ingredients needed:

1. **Superimposed** — `Q` becomes super_slave `P\Q` with two lords, ordered `[1] = P (pipe)`, `[2] = Q (quadrupole)`.
2. **Collective effects** — `track1_bunch_csr` slices the super_slave into `n_step` runts. Each runt is a `slice_slave` with `n_lord = 2`. Still correct here.
3. **Wakes** — for the *one* runt containing the wake location (the wake sits at the lord's center, so only one runt qualifies — `pointer_to_wake_ele`), `track1_bunch_hom` splits that runt in two to apply the wake at the midpoint (`beam_utils.f90:110`). That is a slice of a slice, and it loses the quadrupole.
4. **Runge-Kutta** — `bmad_standard` tracks from `%value(...)` and never consults the lords, so only field-based tracking is affected.

Exactly one runt out of `n_step` is field-free, which is why the deficit is precisely one `ds_track_step` and the reported ratios are (n-1)/n for n = 2, 20, 200.

## Verification

`rms px` at END for the issue's MWE, same source otherwise:

| ds_track_step | bmad_standard | R-K before | R-K after |
|---|---|---|---|
| 0.1   | 1.98671372E-04 | 9.98378899E-05 | 1.98671372E-04 |
| 0.01  | 1.98671372E-04 | 1.88771338E-04 | 1.98671372E-04 |
| 0.001 | 1.98671372E-04 | 1.97681351E-04 | 1.98671372E-04 |
| off   | 1.98671372E-04 | 1.98671372E-04 | 1.98671372E-04 |

`regression_tests`: 53 passed, 3 skipped (`test_fortran.py`).

`rms z` also shifts slightly (9.99978E-06 to 9.99779E-06), for `bmad_standard` too — that is the `compute_reference_energy.f90:1023` path above now picking the quadrupole instead of the pipe.

## Scope beyond this issue

Any second-level slice of a multi-lord super_slave was affected, not just the CSR wake path — `radiation_map_setup` (`radiation_mod.f90:233`) also slices whatever element `track1_bunch_hom` hands it.

No regression test is added here; a superimposed-quad + wake + CSR case in `csr_and_space_charge_test` would be the natural home if you want one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
