### PR TITLE
Make out_io thread safe when called from an OpenMP parallel region

### DIFF
--- a/bmad/space_charge/csr_and_space_charge_mod.f90
+++ b/bmad/space_charge/csr_and_space_charge_mod.f90
@@ -1532,9 +1532,7 @@ if (ele%csr_method == one_dim$ .or. ele%space_charge_method == slice$) then
       r1 = (zp - csr%slice(i0)%z_center) / csr%dz_slice
       r0 = 1 - r1
       if (r1 < -0.01_rp .or. r1 > 1.01_rp .or. i0 < 1 .or. i0 >= space_charge_com%n_bin) then
-        !$OMP critical
         call out_io (s_error$, 'csr_and_sc_apply_kicks', 'CSR INTERNAL ERROR!')
-        !$OMP end critical
         if (global_com%exit_on_error) call err_exit
       endif
       particle(ip)%vec(6) = particle(ip)%vec(6) + r0 * csr%slice(i0)%kick_csr + r1 * csr%slice(i0+1)%kick_csr
@@ -1556,9 +1554,7 @@ if (ele%csr_method == one_dim$ .or. ele%space_charge_method == slice$) then
 
     ! r1 should be in [0,1] but allow for some round-off error
     if (r1 < -0.01_rp .or. r1 > 1.01_rp .or. i0 < 1 .or. i0 >= space_charge_com%n_bin) then
-      !$OMP critical
       call out_io (s_error$, 'csr_and_sc_apply_kicks', 'CSR INTERNAL ERROR!')
-      !$OMP end critical
       if (global_com%exit_on_error) call err_exit
     endif
 

--- a/sim_utils/io/output_mod.f90
+++ b/sim_utils/io/output_mod.f90
@@ -42,6 +42,25 @@ end type
 type (out_io_mod_com_struct), save, private :: out_io_com
 type (out_io_output_direct_struct), save, private :: out_io_direct
 
+! Thread safety:
+! out_io is reachable from within OpenMP parallel regions. For example, track1_bunch_hom and
+! track_bunch_time track the particles of a bunch in parallel and a per-particle tracking error
+! (Runge-Kutta step size too small, etc.) results in an out_io call from every thread.
+! Emitting a message mutates shared state: the capture buffer (out_io_com%n_buffer_lines along with
+! the out_io_com%buffer allocation) and the file/terminal units. Without serialization, two threads
+! can grow the capture buffer at the same time which corrupts the heap and aborts the program.
+! Therefore the out_io routines serialize the entire message with an OpenMP critical region.
+! The entire message and not just individual lines is serialized so that lines from different
+! threads are not interleaved and so that the out_io_called / out_io_line / out_io_end bracketing
+! that a program may use for capturing output is not broken up.
+!
+! Two things to keep in mind:
+!   1) The critical region MUST be named. All unnamed critical regions in a program share a single
+!      lock and critical regions are not reentrant. Since a calling routine may well guard its own
+!      out_io call with an unnamed critical region, an unnamed region here could deadlock.
+!   2) The out_io_called, out_io_line, and out_io_end routines, which a program may override to
+!      capture output, are called with the lock held. An override must not itself call out_io.
+
 private out_io_line12, out_io_int, out_io_real, out_io_logical
 private header_io, find_format, out_io_lines, insert_numbers, out_io_line_out
 
@@ -265,6 +284,8 @@ logical, optional :: insert_tag_line
 if (global_rank /= 0) return  ! For running under MPI
 if (level == s_nooutput$) return
 
+!$OMP critical (out_io_emit)
+
 call header_io (level, routine_name, insert_tag_line)
 
 call find_format (line, n_prefix, fmt, ix1, ix2, found)
@@ -277,6 +298,8 @@ else
 endif
 
 if (out_io_direct%print_and_capture(level) .and. out_io_com%capture_state == 'UNBUFFERED') call out_io_end()
+
+!$OMP end critical (out_io_emit)
 
 end subroutine out_io_real
 
@@ -309,6 +332,8 @@ logical, optional :: insert_tag_line
 if (global_rank /= 0) return  ! For running under MPI
 if (level == s_nooutput$) return
 
+!$OMP critical (out_io_emit)
+
 call header_io (level, routine_name, insert_tag_line)
 
 call find_format (line, n_prefix, fmt, ix1, ix2, found)
@@ -321,6 +346,8 @@ else
 endif
 
 if (out_io_direct%print_and_capture(level) .and. out_io_com%capture_state == 'UNBUFFERED') call out_io_end()
+
+!$OMP end critical (out_io_emit)
 
 end subroutine out_io_int
 
@@ -353,6 +380,8 @@ logical, optional :: insert_tag_line
 if (global_rank /= 0) return  ! For running under MPI
 if (level == s_nooutput$) return
 
+!$OMP critical (out_io_emit)
+
 call header_io (level, routine_name, insert_tag_line)
 
 call find_format (line, n_prefix, fmt, ix1, ix2, found)
@@ -365,6 +394,8 @@ else
 endif
 
 if (out_io_direct%print_and_capture(level) .and. out_io_com%capture_state == 'UNBUFFERED') call out_io_end()
+
+!$OMP end critical (out_io_emit)
 
 end subroutine out_io_logical
 
@@ -400,6 +431,8 @@ integer level, nr, ni, nl
 if (global_rank /= 0) return  ! For running under MPI
 if (level == s_nooutput$) return
 
+!$OMP critical (out_io_emit)
+
 call header_io (level, routine_name, insert_tag_line)
 
 nr = 0; ni = 0; nl = 0  ! number of numbers used.
@@ -418,6 +451,8 @@ if (present(line11)) call insert_numbers (level, fmt, nr, ni, nl, line11, r_arra
 if (present(line12)) call insert_numbers (level, fmt, nr, ni, nl, line12, r_array, i_array, l_array, insert_tag_line)
 
 if (out_io_direct%print_and_capture(level) .and. out_io_com%capture_state == 'UNBUFFERED') call out_io_end()
+
+!$OMP end critical (out_io_emit)
 
 end subroutine out_io_line12
 
@@ -450,6 +485,8 @@ integer level, i, nr, ni, nl
 if (global_rank /= 0) return  ! For running under MPI
 if (level == s_nooutput$) return
 
+!$OMP critical (out_io_emit)
+
 call header_io (level, routine_name, insert_tag_line)
 
 nr = 0; ni = 0; nl = 0  ! number of numbers used.
@@ -459,6 +496,8 @@ do i = 1, size(lines)
 enddo
 
 if (out_io_direct%print_and_capture(level) .and. out_io_com%capture_state == 'UNBUFFERED') call out_io_end()
+
+!$OMP end critical (out_io_emit)
 
 end subroutine out_io_lines
 


### PR DESCRIPTION
Fixes #2164.

### The bug

`out_io` is reachable from inside OpenMP parallel regions: `track1_bunch_hom` (`bmad/multiparticle/beam_utils.f90:81`) and `track_bunch_time` (`bmad/multiparticle/track_bunch_time.f90:57`) track the particles of a bunch in parallel, and a per-particle tracking error — in the reproducer, `odeint_bmad` hitting `max_num_runge_kutta_step` (`bmad/modules/runge_kutta_mod.f90:288`) — calls `out_io` from every thread at once.

`out_io_line_out` then mutates module-global state with no synchronization:

```fortran
out_io_com%n_buffer_lines = out_io_com%n_buffer_lines + 1                    ! racy read-modify-write
if (.not. allocated(out_io_com%buffer)) allocate (out_io_com%buffer(20))     ! two threads can both allocate
if (n_buffer_lines > size(buffer)) call re_allocate (out_io_com%buffer, ...) ! two threads can both grow
out_io_com%buffer(out_io_com%n_buffer_lines) = line_out                      ! index may be stale / out of bounds
```

`re_allocate_string` does `move_alloc` → `allocate` → copy → `deallocate`, so two threads in there at once means one frees the buffer the other is still copying from or writing into. The result is heap corruption, which reaches pytao as garbage bytes out of `tao_c_out_io_buffer_get_line` (`UnicodeDecodeError: ... invalid continuation byte`) or as an outright `malloc` abort.

Only the buffered-capture path corrupts memory, which is why plain `tao` does not show this: `capture_state` is set to `'BUFFERED'` only by `tao_c_interface_mod.f90:106`, i.e. the pytao path.

### The fix

A named OpenMP critical region, `out_io_emit`, around the body of each of the five `out_io` entry routines (`out_io_real`, `out_io_int`, `out_io_logical`, `out_io_line12`, `out_io_lines`), placed after the early returns.

Two points worth noting, both written up in a comment at the top of `output_mod.f90`:

* **The lock covers a whole message, not a single line.** Locking only `out_io_line_out` would fix the memory corruption but still let lines from different threads interleave, and would leave the `out_io_called` / `out_io_line` / `out_io_end` bracketing (used by programs that override those hooks to capture output) split across threads, since `out_io_called` is issued by `header_io` before the first line and `out_io_end` after the last one.
* **The region must be named.** All unnamed critical regions in a program share one lock and critical regions are not reentrant, so an unnamed region here would deadlock against a caller that guards its own `out_io` call with an unnamed critical. `csr_and_sc_apply_kicks` did exactly that; those two guards are now redundant and are removed here (they also needlessly contended with the unrelated reduction criticals in the same module).

One consequence to be aware of: the overridable `out_io_called` / `out_io_line` / `out_io_end` routines are now called with the lock held, so an override must not itself call `out_io`. Noted in the comment.

### Testing

`sim_utils/io/output_mod.f90` and `bmad/space_charge/csr_and_space_charge_mod.f90` both compile clean with `-fopenmp`, and the named lock symbol (`gomp_critical_user_out_io_emit`) is emitted rather than the anonymous one.

Beyond that, a standalone driver calls `out_io` with a 5-line message (plus header) from an `!$OMP parallel do` of 20000 iterations with `capture_state = 'BUFFERED'`, then checks the buffer for line count, garbage lines, and split messages. With `OMP_NUM_THREADS=8`:

| | lines (expect 120000) | garbage lines | split messages |
|---|---|---|---|
| `main` | 119926 / 119936 / 119928, and a `SIGABRT` in `malloc` on the 4th run | 184 / 45065 / 34 | — |
| lock in `out_io_line_out` only | 120000 | 0 | ~19800 of 20000 |
| this PR | 120000 (10/10 runs) | 0 | 0 |

The reproducer attached to #2164 exercises the same path through pytao.

Credit to @Nathan-Majernik for the report, the reproducer, and the diagnosis — including the point about the critical region needing a name. This PR is their fix with the lock moved up to the entry routines and the now-redundant CSR guards removed.
