### PR TITLE
s_start is already accounted for at the start of the code

### DIFF
--- a/bmad/space_charge/csr_and_space_charge_mod.f90
+++ b/bmad/space_charge/csr_and_space_charge_mod.f90
@@ -2016,7 +2016,7 @@ do i_step = 0, n_step
     call convert_pc_to (p%p0c * (1 + p%vec(6)), p%species, beta = p%beta)
   enddo
 
-  call save_a_bunch_step (ele, bunch, bunch_track, s0_step+s_start)
+  call save_a_bunch_step (ele, bunch, bunch_track, s0_step)
 
 enddo
 


### PR DESCRIPTION
`s_start` is already added to `s0_step` early in this subroutine.  Including it here was double counting.  Additionally, `s_start` is optional and this call is not protected by an `if(present(s_Start))`, thus leading to a crash if `s_start` is not present.

```
call save_a_bunch_step (ele, bunch, bunch_track, s0_step+s_start)
```

This fix simply removes `s_start` from this call.