### PR TITLE
Fix memory leak of %rad_map with temporary (slice) elements

### DIFF
--- a/bmad/code/create_element_slice.f90
+++ b/bmad/code/create_element_slice.f90
@@ -77,6 +77,9 @@ endif
 !
 
 if (.not. associated(sliced_ele%lord, ele_in) .or. sliced_ele%ix_ele /= ix_slice_slave$) then
+  ! Note: transfer_ele with nullify_pointers = True only nullifies the pointers of sliced_ele. So any
+  ! memory (EG %rad_map) that sliced_ele owns must be deallocated here to prevent a memory leak.
+  call deallocate_ele_pointers(sliced_ele)
   call transfer_ele(ele_in, sliced_ele, .true.)
 endif
 
@@ -230,13 +233,19 @@ elseif (ele_has_constant_ds_dt_ref(ele_in)) then
   sliced_ele%time_ref_orb_in%vec = 0
 
 else
-  call transfer_ele (sliced_ele, ele2)
+  ! Note: The pointers of ele2 are nullified so that ele2 does not share memory with sliced_ele.
+  ! Otherwise the deallocate_ele_pointers call above would deallocate memory owned by sliced_ele.
+  call transfer_ele (sliced_ele, ele2, .true.)
   call create_element_slice (ele2, ele_in, offset, 0.0_rp, param, .true., .false., err2_flag)
-  if (err2_flag) return
+  if (err2_flag) then
+    call deallocate_ele_pointers (ele2)
+    return
+  endif
   ele0%value(p0c$)      = ele2%value(p0c$)
   ele0%value(e_tot$)    = ele2%value(e_tot$)
   ele0%ref_time         = ele2%ref_time
   sliced_ele%time_ref_orb_in = ele2%time_ref_orb_out
+  call deallocate_ele_pointers (ele2)   ! ele2 is a local temporary so avoid a memory leak.
 endif
 
 ele0%ref_species = ele_in%ref_species

--- a/bmad/code/element_slice_iterator.f90
+++ b/bmad/code/element_slice_iterator.f90
@@ -58,6 +58,9 @@ s0 = real_option((i_slice-1)*ds, s_start)
 s1 = real_option(i_slice*ds, s_end)
 
 if (i_slice == 1) then
+  ! Any pointers (EG %rad_map) that sliced_ele owns from a previous element must be deallocated here.
+  ! Transfer_ele with nullify_pointers = True will only nullify and this would orphan the memory.
+  call deallocate_ele_pointers (sliced_ele)
   call transfer_ele (ele, sliced_ele, .true.)
 endif
 

--- a/bmad/low_level/deallocate_ele_pointers.f90
+++ b/bmad/low_level/deallocate_ele_pointers.f90
@@ -88,11 +88,18 @@ if (associated (ele%mode3))                     deallocate (ele%mode3)
 if (associated (ele%rf))                        deallocate (ele%rf)
 if (associated (ele%wake))                      deallocate (ele%wake)
 if (associated (ele%high_energy_space_charge))  deallocate (ele%high_energy_space_charge)
-if (associated (ele%gen_gradients))              deallocate (ele%gen_gradients)
 
 if (allocated (ele%multipole_cache))            deallocate (ele%multipole_cache)
 
 call unlink_wall3d (ele%wall3d)
+
+! Note: Do not use a simple "deallocate (ele%gen_gradients)" here. Gfortran does not deallocate the
+! allocatable components of the elements of a pointer array when the array itself is deallocated so
+! unlink_fieldmap, which deallocates %curve by hand, must be used to avoid a memory leak.
+
+if (associated (ele%gen_gradients)) then
+  call unlink_fieldmap (gen_gradients = ele%gen_gradients)
+endif
 
 if (associated (ele%cartesian_map)) then
   call unlink_fieldmap (cartesian_map = ele%cartesian_map)

--- a/bmad/low_level/unlink_fieldmap.f90
+++ b/bmad/low_level/unlink_fieldmap.f90
@@ -53,7 +53,7 @@ endif
 
 if (present(gen_gradients)) then
   do i = 1, size(gen_gradients)
-    deallocate (gen_gradients(i)%curve)
+    if (allocated(gen_gradients(i)%curve)) deallocate (gen_gradients(i)%curve)
   enddo
   deallocate (gen_gradients)
 endif

--- a/bmad/modules/radiation_mod.f90
+++ b/bmad/modules/radiation_mod.f90
@@ -248,6 +248,11 @@ call tracking_rad_map_setup (runt, 1e-4_rp, downstream_end$, ele%rad_map%rm1, er
 8000 continue
 bmad_com = bmad_com_save
 
+! runt is a local temporary. Fortran does not deallocate the pointer components of a local
+! variable so this must be done by hand to prevent a memory leak.
+
+call deallocate_ele_pointers (runt)
+
 end subroutine radiation_map_setup
 
 !---------------------------------------------------------------------------

--- a/bmad/multiparticle/beam_utils.f90
+++ b/bmad/multiparticle/beam_utils.f90
@@ -114,6 +114,7 @@ else
 
   if (err_flag) then
     if (global_com%exit_on_error) call err_exit
+    call deallocate_ele_pointers (half_ele)
     return
   endif
 
@@ -144,6 +145,7 @@ endif
 
 if (ele%value(l$) == 0) then
   bunch%charge_live = sum (bunch%particle(:)%charge, mask = (bunch%particle(:)%state == alive$))
+  call deallocate_ele_pointers (half_ele)
   return
 endif
 
@@ -168,6 +170,11 @@ if (bunch%charge_live == 0) then
 endif
 
 call save_a_bunch_step (ele, bunch, bunch_track, ele%value(l$))
+
+! half_ele is a local temporary. Fortran does not deallocate pointer components (EG %rad_map which
+! is allocated by radiation_map_setup) of a local variable so this must be done by hand.
+
+call deallocate_ele_pointers (half_ele)
 
 end subroutine track1_bunch_hom
 

--- a/bmad/parsing/parser_set_attribute_mod.f90
+++ b/bmad/parsing/parser_set_attribute_mod.f90
@@ -1660,9 +1660,12 @@ if (attrib_word == 'GEN_GRADIENTS') then
     allocate(ele%gen_gradients(i_ptr))
     allocate(ele%gen_gradients(i_ptr)%curve(0))
     do i = 1, i_ptr-1
-      ele%gen_gradients(i) = ele0%gen_gradients(i)
+      ele%gen_gradients(i) = ele0%gen_gradients(i)   ! Note: This is a deep copy of %curve.
     enddo
-    deallocate(ele0%gen_gradients)
+    ! Note: unlink_fieldmap is used here, and not a simple deallocate, since gfortran does not
+    ! deallocate the allocatable components of the elements of a pointer array when the array
+    ! itself is deallocated.
+    call unlink_fieldmap (gen_gradients = ele0%gen_gradients)
   else
     allocate(ele%gen_gradients(1))
     allocate(ele%gen_gradients(1)%curve(0))

--- a/tao/code/tao_expression_tree_mod.f90
+++ b/tao/code/tao_expression_tree_mod.f90
@@ -179,9 +179,12 @@ if (associated(tree%node)) then
   n_save = min(n, n_old)
   temp_tree%node => tree%node
   allocate (tree%node(n))
-  tree%node(1:n_save) = temp_tree%node(1:n_save)
+  tree%node(1:n_save) = temp_tree%node(1:n_save)   ! Note: This is a deep copy of the allocatable components.
   do in = n_save+1, n_old
     call tao_deallocate_tree(temp_tree%node(in))
+  enddo
+  do in = 1, n_old
+    call deallocate_node_components(temp_tree%node(in))
   enddo
   deallocate (temp_tree%node)  
 else
@@ -216,10 +219,42 @@ if (.not. associated(tree%node)) return
 
 do in = 1, size(tree%node)
   call tao_deallocate_tree(tree%node(in))
+  call deallocate_node_components(tree%node(in))
 enddo
 
 deallocate(tree%node)
 
 end subroutine 
+
+!-------------------------------------------------------------------------
+!-------------------------------------------------------------------------
+!-------------------------------------------------------------------------
+!+
+! Subroutine deallocate_node_components (node)
+!
+! Routine to deallocate the allocatable components of a tree node.
+!
+! Note: This is needed since gfortran does not deallocate the allocatable components of the
+! elements of a pointer array when the array itself is deallocated. Without this there is a
+! memory leak every time an expression is evaluated.
+!
+! Input:
+!   node      -- tao_eval_node_struct: Node to clean up.
+!
+! Output:
+!   node      -- tao_eval_node_struct: Node with allocatable components deallocated.
+!-
+
+subroutine deallocate_node_components (node)
+
+type (tao_eval_node_struct) node
+
+!
+
+if (allocated(node%value))     deallocate(node%value)
+if (allocated(node%info))      deallocate(node%info)
+if (allocated(node%value_ptr)) deallocate(node%value_ptr)
+
+end subroutine deallocate_node_components
 
 end module

--- a/tao/code/tao_lattice_calc_mod.f90
+++ b/tao/code/tao_lattice_calc_mod.f90
@@ -699,6 +699,11 @@ enddo
 
 if (associated(ele%rad_map)) ele%rad_map = rad_map_save
 
+! slice_ele is a local temporary. Fortran does not deallocate the pointer components (EG %rad_map)
+! of a local variable so this must be done by hand to prevent a memory leak.
+
+call deallocate_ele_pointers (slice_ele)
+
 ! only post total lost if no extraction or extracting to a turned off lattice
 
 n_lost = 0


### PR DESCRIPTION
Fixes #2175.

Three memory leaks found while chasing the OOM reported in #2175. The first is the one that causes the OOM; the other two were found with the macOS `leaks` tool while verifying the fix.

## 1. `%rad_map` allocated on temporary (slice) elements

`radiation_map_setup` allocates `ele%rad_map` for whatever element it is passed:

```fortran
if (.not. associated(ele%rad_map)) allocate(ele%rad_map)
```

It is repeatedly called with **temporary** elements, and `%rad_map` is a pointer, so the memory is orphaned when:

* `transfer_ele (..., nullify_pointers = True)` nullifies (but does not deallocate) the pointers of the destination element, or
* a local `ele_struct` goes out of scope (Fortran does not deallocate pointer components of a local variable).

With beam tracking and radiation damping/fluctuations on this leaks one `rad_map` (~2 KB) per sliced or wake element per track, so any long running Tao/PyTao process that re-tracks a beam in a loop grows without bound. This is what is being seen at SLAC with the `cu_hxr` digital twin (`cu_hxr/tao.init` sets `bmad_com%radiation_fluctuations_on = T`): 269 MB -> 4.6 GB in 17 hours at 0.76 tracks/sec.

Per-track leak sites from a `leaks` run on the reported `cu_hxr` `OTR2:TD11` case with `comb_ds_save = 0.1`:

```
~43 blocks  radiation_map_setup < tao_beam_track                                  (comb slice path)
 ~9 blocks  radiation_map_setup < track1_bunch_hom < track1_bunch < tao_beam_track (wake path, 1st half)
 ~9 blocks  radiation_map_setup < track1_bunch_hom < track1_bunch < tao_beam_track (wake path, 2nd half)
```

~124 KB/track, independent of `n_particle` (verified with 200 vs 1000 particles) and independent of whether any results are read back.

Fix:

* `create_element_slice`: deallocate `sliced_ele`'s pointers before the nullifying `transfer_ele`. This is the dominant leak: when `ele_in` is itself a `slice_slave` (as it is for Tao's comb slices, since the slice's `%lord` is set to `ele_in%lord`), the "already a slice of this element" reuse test fails on every call so the pointers were re-nullified and orphaned each time. The shallow copy into the local `ele2` is changed to nullify pointers so `ele2` never aliases memory owned by `sliced_ele`, and `ele2` is cleaned up before return.
* `element_slice_iterator`, `track1_bunch_hom`, `radiation_map_setup`, `tao_beam_track`: deallocate the pointers of the local temporary elements (`sliced_ele`, `half_ele`, `runt`, `slice_ele`).

## 2 and 3. Allocatable components orphaned when a pointer array is deallocated

Gfortran does not deallocate the allocatable components of the elements of a **pointer array** when the array itself is deallocated. It does so correctly for an allocatable array and for a scalar pointer. Measured with a standalone test program, 200k allocate/deallocate cycles of a type with one `real, allocatable :: v(:)` component:

| deallocated entity | result |
|---|---|
| pointer array | components leak (+178 MB) |
| allocatable array | components freed (flat) |
| scalar pointer | components freed (flat) |

Same on gfortran 13.4 and 15.2, at `-O0` and `-O2`. `unlink_wall3d` and `unlink_fieldmap` already work around this by deallocating `%section` and `%curve` by hand, but two other places did not:

* **`tao_deallocate_tree`** (and `tao_re_associate_node_array`): `tao_eval_node_struct` keeps its children in the pointer array `%node(:)` and its data in the allocatable `%value`, `%info` and `%value_ptr`. Every expression evaluation therefore leaked the arrays of one node — 48 bytes per `set ele <ele> <attrib> = <value>` command. Fixed by deallocating the components by hand before the array is deallocated.
* **`deallocate_ele_pointers`** and the `GEN_GRADIENTS` parsing code used a plain `deallocate` on the `ele%gen_gradients(:)` pointer array, orphaning the `%curve` arrays which hold the derivative tables. Both now use `unlink_fieldmap`. The `%curve` deallocate in `unlink_fieldmap` is also guarded with an `allocated` test.

A sweep of the other pointer arrays whose element type has allocatable components (`%ele`, `%wall3d`, `%model_branch`, `%d`, `%v`, and the Bmad `expression_tree_struct%node`) found them all either already handled by hand or never deallocated as pointer arrays.

## Verification

Real `cu_hxr` lattice, `-slice_lattice OTR2:TD11`, `n_particle = 1000`, `comb_ds_save = 0.1`, repeated quad changes forcing a re-track:

| | peak RSS @ 10 tracks | @ 40 tracks | leaked bytes (`leaks`) |
|---|---|---|---|
| before | 128.7 MB | 138.7 MB | 6.50 MB / 10 tracks, ~517 `rad_map` blocks |
| after all three fixes | 139.9 MB | 140.9 MB | 112 bytes / 40 tracks |

The 112 bytes are 5 one-time `read_digested_bmad_file` blocks plus one C++ runtime global. The `generalized_gradient_test` regression test loses its two orphaned `parse_gen_gradients` blocks (1728 bytes with subblocks).

Regression tests after each commit: 10971 comparisons, and all 61 `output.now` files byte identical to the unpatched build. The one failing test on my machine (`rf_test`, 4 datums) fails identically with and without these changes.

Diagnosis, patches, and verification by Claude Opus 5 (Claude Code); reviewed by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
