### PR TITLE
Fix segfault from scratch%eles aliasing in expression plot curves

### DIFF
--- a/tao/code/tao_evaluate_element_parameters.f90
+++ b/tao/code/tao_evaluate_element_parameters.f90
@@ -33,6 +33,7 @@ implicit none
 type (tao_universe_struct), pointer :: u
 type (ele_struct), pointer, optional :: dflt_ele
 type (tao_expression_info_struct), allocatable, optional :: info(:)
+type (ele_pointer_struct), allocatable :: eles(:)
 
 character(*) param_name
 character(*) dflt_source
@@ -135,17 +136,21 @@ if (use_dflt_ele) then
   endif
 
 else
+  ! Note: Use a local eles(:) array here and not the global scratch%eles. Reason is that a caller
+  ! (EG tao_curve_datum_calc) may be looping over scratch%eles when calling this routine and
+  ! reallocating scratch%eles here would invalidate the caller's array.
+
   do i = lbound(s%u, 1), ubound(s%u, 1)
     if (.not. this_u(i)) cycle
     u => s%u(i)
-    call tao_locate_elements (class_ele, u%ix_uni, scratch%eles, err)
+    call tao_locate_elements (class_ele, u%ix_uni, eles, err)
     if (err) return
-    call re_allocate (values, n_tot + size(scratch%eles))
-    if (present(info)) call tao_re_allocate_expression_info(info, n_tot+size(scratch%eles))
+    call re_allocate (values, n_tot + size(eles))
+    if (present(info)) call tao_re_allocate_expression_info(info, n_tot+size(eles))
 
-    do j = 1, size(scratch%eles)
-      call evaluate_this_parameter(scratch%eles(j)%ele, parameter, component, where, u, n_tot, values, err)
-      if (present(info)) info(n_tot)%ele => scratch%eles(j)%ele
+    do j = 1, size(eles)
+      call evaluate_this_parameter(eles(j)%ele, parameter, component, where, u, n_tot, values, err)
+      if (present(info)) info(n_tot)%ele => eles(j)%ele
       if (err) return
     enddo
   enddo


### PR DESCRIPTION
## Summary

Tao crashes with a segmentation fault when a plot curve uses `data_source = "lat"` or `"beam"` and its `data_type` is an expression containing an element-parameter term such as `ele::#[e_tot]`.

## Root cause

`tao_curve_datum_calc` (`tao/code/tao_graph_setup_mod.f90`) iterates over the module-global `scratch%eles` array, calling `tao_evaluate_a_datum` once per element:

```fortran
do ie = 1, n_dat
  datum%ix_ele = eles(ie)%ele%ix_ele
  ...
  call tao_evaluate_a_datum (datum, u, u%model, y_val, valid, why_invalid)
enddo
```

For an `expression:` data type containing an `ele::` term, that call reaches `tao_evaluate_element_parameters`, which was passing the *same* global array to `tao_locate_elements`:

```fortran
call tao_locate_elements (class_ele, u%ix_uni, scratch%eles, err)
```

`tao_locate_elements` reallocates its `eles` argument. The array the caller is still looping over is therefore replaced mid-iteration, `n_dat` becomes stale, and the remaining `eles(ie)%ele` accesses read past the new bounds or dereference null pointers.

Confirmed under `lldb`: `EXC_BAD_ACCESS` in `tao_curve_datum_calc` at `datum%ix_ele = eles(ie)%ele%ix_ele`, with the array descriptor showing `ubound = 1` while the loop index had reached 4.

## Change

`tao/code/tao_evaluate_element_parameters.f90` now uses a local `eles(:)` array instead of `scratch%eles`, so the routine no longer perturbs global state belonging to its caller. A comment records why the global must not be used here.

11 insertions, 6 deletions in one file. No interface or behavior change.

## Reproducer

Crashes before the change, works after:

```fortran
&tao_template_plot
  plot%name        = "p"
  plot%x_axis_type = "s"
  plot%n_graph     = 1
  default_curve%data_source = "lat"
/

&tao_template_graph
  graph_index = 1
  graph%name  = "g"
  curve(1)%data_type = "expression: lat::beta.a * ele::#[e_tot]"
/
```

The same failure can be triggered at runtime on any placed lattice plot:

```
set curve <plot>.g.a data_type = expression: lat::beta.a * ele::#[e_tot]
```

## Testing

Built with `mk` (production, gfortran) and exercised against `bmad-doc/tao_examples/optics_matching`. Both the namelist template and the runtime `set curve` form now report `valid = T` and produce the expected curve values; neither crashes.

## Acknowledgement

The crash was diagnosed and this fix was drafted with the assistance of GitHub Copilot (Claude Opus 5), which symbolicated the backtrace, traced the aliasing between `tao_curve_datum_calc` and `tao_evaluate_element_parameters`, and produced the reproducer. All changes were reviewed and verified by the author.
